### PR TITLE
tree command, reimplementation of `doctrine:phpcr:node:dump` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 
 - New command: `file:import`: - import files into the repository.
+- `node:list`: Added `--level` option to rescursively show children nodes and properties
 
 ## Improvements
 

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeTreeCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeTreeCommand.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace PHPCR\Shell\Console\Command\Phpcr;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use PHPCR\NodeInterface;
+
+class NodeTreeCommand extends NodeListCommand
+{
+    protected $textHelper;
+    protected $session;
+
+    protected $showChildren;
+    protected $showProperties;
+
+    protected function configure()
+    {
+        parent::configure();
+        $this->setName('node:tree');
+        $this->setDescription('Display the current node as a tree');
+        $this->addArgument('path', InputArgument::OPTIONAL, 'Path of node', '.');
+        $this->addOption('filter', 'f', InputOption::VALUE_REQUIRED|InputOption::VALUE_IS_ARRAY, 'Optional filter to apply');
+        $this->addOption('level', 'L', InputOption::VALUE_REQUIRED, 'Depth of tree to show');
+        $this->setHelp(<<<HERE
+HERE
+        );
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->formatter = $this->getHelper('result_formatter');
+        $this->textHelper = $this->getHelper('text');
+        $this->session = $this->getHelper('phpcr')->getSession();
+
+        $this->filters = $input->getOption('filter');
+        $this->level = $input->getOption('level');
+
+        $this->showChildren = $input->getOption('children');
+        $this->showProperties = $input->getOption('properties');
+
+        $path = $session->getAbsPath($input->getArgument('path'));
+        $currentNode = $session->getNode($path);
+
+        if (!$showChildren && !$showProperties) {
+            $this->showChildren = true;
+            $this->showProperties = true;
+        }
+
+        $output->writeln('<node>.</node>');
+        $this->renderNode($currentNode, 1);
+    }
+
+    protected function renderNode(NodeInterface $node, OutputInterface $output)
+    {
+        foreach ($node->getNodes($this->filters ? : null) as $child) {
+            $output->writeln($this->formatNode($child));
+        }
+    }
+
+    protected function formatNode(NodeInterface $node)
+    {
+        return '<node>' . $this->formatter->formatNodeName($child) . '</node>';
+    }
+}


### PR DESCRIPTION
Added level option to `node:list` command, show node hierarchy, equivalent of `doctrine:phpcr:node:dump` command

```
PHPCRSH> node:list --level=3
PHPCRSH> node:list -L3
+------------------------+-----------------+---------------------------------------------------------+
| page/                  | nt:unstructured |                                                         |
| | main                 | nt:unstructured |                                                         |
| | | jcr:primaryType    | NAME            | nt:unstructured                                         |
| | | jcr:mixinTypes     | NAME            | [0] phpcr:managed                                       |
|                        |                 | [1] mix:referenceable                                   |
| | | phpcr:class        | STRING          | Symfony\Cmf\Bundle\RoutingAutoBundle\Document\AutoRoute |
| | | phpcr:classparents | STRING          | [0] Symfony\Component\Routing\Route                     |
|                        |                 | [1] Symfony\Cmf\...                                     |
| | | jcr:uuid           | STRING          | 1944d5b2-a036-4a06-b51b-6d6d6ecad5af                    |
| | | host               | STRING          |                                                         |
| | | defaults           | STRING          |                                                         |
| | | requirements       | STRING          |                                                         |
| | | options            | STRING          |                                                         |
| | | addFormatPattern   | BOOLEAN         | false                                                   |
| | | addTrailingSlash   | BOOLEAN         | false                                                   |
| | | routeContent       | WEAKREFERENCE   | 3ae8261a-c2f6-4289-8bd6-dd76891816d5                    |
| | | fooo               | STRING          | barrrr                                                  |
```
