### PR TITLE
Aliases do not resepect parenthesis escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,7 @@
 
 - `session:export:view`: Added `--pretty` option to `session:export:view` command to output formatted XML.
 - `session:export:view`: Ask confirmation before overwriting file.
+
+## Bug Fixes
+
+- Aliases: Allow quoted arguments

--- a/features/fixtures/cms.xml
+++ b/features/fixtures/cms.xml
@@ -32,6 +32,11 @@
         <sv:property sv:name="jcr:mixinTypes" sv:type="name">
             <sv:value>mix:shareable</sv:value>
         </sv:property>
+        <sv:node sv:name="Title with Spaces">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:unstructured</sv:value>
+            </sv:property>
+        </sv:node>
         <sv:node sv:name="article1">
             <sv:property sv:name="jcr:primaryType" sv:type="Name">
                 <sv:value>nt:unstructured</sv:value>

--- a/features/shell_alias.feature
+++ b/features/shell_alias.feature
@@ -7,6 +7,11 @@ Feature: Command aliases
         Given that I am logged in as "testuser"
         And the "cms.xml" fixtures are loaded
 
+    Scenario: Execute an alias with a quoted string
+        Given I execute the "ls 'cms/articles/Title with Spaces'" command
+        Then the command should not fail
+
+
     Scenario Outline: Execute an alias
         Given I execute the "<command>" command
         Then the command should not fail
@@ -20,8 +25,9 @@ Feature: Command aliases
             | mv cms smc |
             | ls |
             | ls cms |
-            | sl cms/articles cms/test/foobar |
+            | ln cms/articles cms/test/foobar |
             | cat cms/articles/article1/title |
+
 
     Scenario: List aliases
         Given I execute the "shell:alias:list" command
@@ -30,6 +36,3 @@ Feature: Command aliases
             | Alias | Command |
             | cd    | shell:path:change {arg1} |
             | ls    | node:list {arg1} |
-
-
-

--- a/src/PHPCR/Shell/Subscriber/AliasSubscriber.php
+++ b/src/PHPCR/Shell/Subscriber/AliasSubscriber.php
@@ -72,6 +72,9 @@ class AliasSubscriber implements EventSubscriberInterface
         $tokens = $input->getTokens();
 
         foreach ($tokens as $i => $token) {
+            if (strstr($token, ' ')) {
+                $token = escapeshellarg($token);
+            }
             $replaces['{arg' . $i . '}'] = $token;
         }
 


### PR DESCRIPTION
```
PHPCRSH > pset title "mytitle"
PHPCRSH > pset title "Welcome to the Slin"
[RuntimeException] Too many arguments.
```
