### PR TITLE
Option to show undefined proerties and children which are in the node type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,22 @@
-# alpha2 / dev-master
+Changelog
+=========
 
-## Features
+alpha-3
+-------
 
-- New command: `file:import`: - import files into the repository.
-- `node:list`: Added `--level` option to rescursively show children nodes and properties
-- Autocomplete completes property names in addition to node names in current path
+### Features
 
-## Improvements
+- [file]: `file:import` - New command to import files into the repository.
+- [node]: `node:list` Added `--level` option to rescursively show children nodes and properties.
+- [node]: `node:list` Show "unulfilled" property and child node definitions when listing node contents.
 
-- `session:export:view`: Added `--pretty` option to `session:export:view` command to output formatted XML.
+### Improvements
+
+- [export]: `session:export:view`: Added `--pretty` option to `session:export:view` command to output formatted XML.
 - `session:export:view`: Ask confirmation before overwriting file.
+- [shell]: Autocomplete completes property names in addition to node names in current path.
 
-## Bugs
+### Bugs
 
-- Aliases: Allow quoted arguments
-- Fixed autocomplete segfault
+- [shell]: *Aliases*: Allow quoted arguments.
+- [shell]: Fixed autocomplete segfault.

--- a/features/phpcr_node_list.feature
+++ b/features/phpcr_node_list.feature
@@ -41,3 +41,22 @@ Feature: List properites and chidren of current node
             | numberPropertyNode/           | nt:file   |                           |
             | NumberPropertyNodeToCompare1/ | nt:file   |                           |
             | NumberPropertyNodeToCompare2/ | nt:file   |                           |
+
+
+    Scenario: List node hierarchy
+        Given the current node is "/"
+        And I execute the "node:list --level=1" command
+        Then the command should not fail
+        And I should see the following:
+        """
+        daniel
+        """
+
+    Scenario: Show templates
+        Given the current node is "/tests_general_base"
+        And I execute the "node:list --template" command
+        Then the command should not fail
+        And I should see the following:
+        """
+        | @*                            | nt:base         |                 |
+        """

--- a/features/shell_autocomplete.feature
+++ b/features/shell_autocomplete.feature
@@ -1,0 +1,5 @@
+Feature: Path autocompletion
+    In order to navigate the tree structure precisely and quickly
+    As a user logged into the shell
+    I need to be able to be able to invoke auto-completion
+

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeListCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeListCommand.php
@@ -25,14 +25,14 @@ class NodeListCommand extends Command
         $this->addOption('properties', null, InputOption::VALUE_NONE, 'List only the properties of this node');
         $this->addOption('filter', 'f', InputOption::VALUE_REQUIRED|InputOption::VALUE_IS_ARRAY, 'Optional filter to apply');
         $this->addOption('level', 'L', InputOption::VALUE_REQUIRED, 'Depth of tree to show');
-        $this->addOption('no-template', 'T', InputOption::VALUE_REQUIRED, 'Do not show template nodes and properties');
+        $this->addOption('template', 't', InputOption::VALUE_NONE, 'Show template nodes and properties');
         $this->setHelp(<<<HERE
 List both or one of the children and properties of this node.
 
 Multiple levels can be shown by using the <info>--level</info> option.
 
-The <info>node:list</info> command also shows template nodes and properties as defined a nodes node-type.
-These can be suppressed using the <info>--no-template</info> option.
+The <info>node:list</info> command can also shows template nodes and properties as defined a nodes node-type by
+using the <info>--template</info> option. Template nodes and properties are prefixed with the "@" symbol.
 HERE
         );
     }
@@ -46,6 +46,7 @@ HERE
 
         $this->showChildren = $input->getOption('children');
         $this->showProperties = $input->getOption('properties');
+        $this->showTemplate = $input->getOption('template');
 
         $session = $this->getHelper('phpcr')->getSession();
 
@@ -113,14 +114,16 @@ HERE
             }
         }
 
-        // render empty schematic children
-        foreach ($childNodeNames as $childNodeName => $childNodeDefinition) {
-            // @todo: Determine and show cardinality, 1..*, *..*, 0..1, etc.
-            $table->addRow(array(
-                '<templatenode>' . implode('', $spacers) . '@' . $childNodeName . '</templatenode>',
-                implode('|', $childNodeDefinition->getRequiredPrimaryTypeNames()),
-                '',
-            ));
+        if ($this->showTemplate) {
+            // render empty schematic children
+            foreach ($childNodeNames as $childNodeName => $childNodeDefinition) {
+                // @todo: Determine and show cardinality, 1..*, *..*, 0..1, etc.
+                $table->addRow(array(
+                    '<templatenode>' . implode('', $spacers) . '@' . $childNodeName . '</templatenode>',
+                    implode('|', $childNodeDefinition->getRequiredPrimaryTypeNames()),
+                    '',
+                ));
+            }
         }
     }
 
@@ -150,12 +153,14 @@ HERE
             ));
         }
 
-        foreach ($propertyNames as $propertyName => $property) {
-            $table->addRow(array(
-                '<templateproperty>' . implode('', $spacers). '@' . $propertyName . '</templateproperty>',
-                '<property-type>' . strtoupper(PropertyType::nameFromValue($property->getRequiredType())) . '</property-type>',
-                ''
-            ));
+        if ($this->showTemplate) {
+            foreach ($propertyNames as $propertyName => $property) {
+                $table->addRow(array(
+                    '<templateproperty>' . implode('', $spacers). '@' . $propertyName . '</templateproperty>',
+                    '<property-type>' . strtoupper(PropertyType::nameFromValue($property->getRequiredType())) . '</property-type>',
+                    ''
+                ));
+            }
         }
     }
 }


### PR DESCRIPTION
This PR adds support for showing "unfulfilled" child nodes and properties as defined in the node type. Below the "template" properties and child nodes are designated with the `@` prefix.

```
PHPCRSH > ls -L3
+--------------------------+------------------+---------------------------------------------------------+
| Europe2014/              | DTLTravel:voyage |                                                         |
| | 2014/                  | DTLTravel:year   |                                                         |
| |   06/                  | DTLTravel:month  |                                                         |
| |     05/                | DTLTravel:day    |                                                         |
| |     @*                 | DTLTravel:day    |                                                         |
| |     jcr:primaryType    | NAME             | DTLTravel:month                                         |
| |     jcr:createdBy      | STRING           | admin                                                   |
| |     jcr:created        | DATE             | 2014-06-06T07:43:45+00:00                               |
| |     jcr:lastModifiedBy | STRING           | admin                                                   |
| |     jcr:lastModified   | DATE             | 2014-06-06T07:43:45+00:00                               |
| |   @*                   | DTLTravel:month  |                                                         |
| |   jcr:primaryType      | NAME             | DTLTravel:year                                          |
| |   jcr:createdBy        | STRING           | admin                                                   |
| |   jcr:created          | DATE             | 2014-06-06T07:43:44+00:00                               |
| |   jcr:lastModifiedBy   | STRING           | admin                                                   |
| |   jcr:lastModified     | DATE             | 2014-06-06T07:43:44+00:00                               |
| | @*                     | DTLTravel:date   |                                                         |
| | jcr:primaryType        | NAME             | DTLTravel:voyage                                        |
| | startDate              | DATE             | 2014-04-21T00:00:00+00:00                               |
| | jcr:createdBy          | STRING           | admin                                                   |
| | jcr:created            | DATE             | 2014-06-04T20:54:13+00:00                               |
| | jcr:lastModifiedBy     | STRING           | admin                                                   |
| | jcr:lastModified       | DATE             | 2014-06-06T14:01:37+00:00                               |
| | description            | STRING           | Santander, Mnt Ventoux, Mnt Blanc, Pass di Simplone,... |
| | @endDate               | DATE             |                                                         |
| Morroco2012              | DTLTravel:voyage |                                                         |
|   @*                     | DTLTravel:date   |                                                         |
|   jcr:primaryType        | NAME             | DTLTravel:voyage                                        |
|   jcr:createdBy          | STRING           | admin                                                   |
|   jcr:created            | DATE             | 2014-06-05T18:59:26+00:00                               |
|   jcr:lastModifiedBy     | STRING           | admin                                                   |
|   jcr:lastModified       | DATE             | 2014-06-05T19:00:07+00:00                               |
|   description            | STRING           | Starting from Paris, went south thorugh the Massive ... |
|   @endDate               | DATE             |                                                         |
|   @startDate             | DATE             |                                                         |
```
