### PR TITLE
Node List accepts UUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ alpha-4
 
 - [node] copy,move and clone - Target paths automatically append basename if target is a node.
 - [query] Always show path next to resultset
+- [node] `node:list` Enable listing nodes by UUID
 
 ### Bugs Fixes
 

--- a/features/phpcr_node_list.feature
+++ b/features/phpcr_node_list.feature
@@ -1,4 +1,4 @@
-Feature: List properites and chidren of current node
+Feature: List properites and chidren of current nodeA
     In order to list the properties and children of the current node
     As a user that is logged into the shell
     I should be able to run a command which does that
@@ -59,4 +59,12 @@ Feature: List properites and chidren of current node
         And I should see the following:
         """
         | @*                            | nt:base         |                 |
+        """
+
+    Scenario: List node by UUID
+        Given I execute the "node:list 842e61c0-09ab-42a9-87c0-308ccc90e6f4" command
+        Then the command should not fail
+        And I should see the following:
+        """
+        jcr:uuid
         """

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeListCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeListCommand.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use PHPCR\PropertyType;
+use PHPCR\Util\UUIDHelper;
 
 class NodeListCommand extends Command
 {
@@ -19,7 +20,7 @@ class NodeListCommand extends Command
     protected function configure()
     {
         $this->setName('node:list');
-        $this->setDescription('List the children / properties of this node');
+        $this->setDescription('List the children / properties of this node at the given path or with the given UUID');
         $this->addArgument('path', InputArgument::OPTIONAL, 'Path of node', '.');
         $this->addOption('children', null, InputOption::VALUE_NONE, 'List only the children of this node');
         $this->addOption('properties', null, InputOption::VALUE_NONE, 'List only the properties of this node');
@@ -33,6 +34,11 @@ Multiple levels can be shown by using the <info>--level</info> option.
 
 The <info>node:list</info> command can also shows template nodes and properties as defined a nodes node-type by
 using the <info>--template</info> option. Template nodes and properties are prefixed with the "@" symbol.
+
+The command accepts wither a path (relative or absolute) to the node or a UUID.
+
+    PHPCRSH> node:list 842e61c0-09ab-42a9-87c0-308ccc90e6f4
+    PHPCRSH> node:list /tests/foobar
 HERE
         );
     }
@@ -50,8 +56,14 @@ HERE
 
         $session = $this->getHelper('phpcr')->getSession();
 
-        $path = $session->getAbsPath($input->getArgument('path'));
-        $currentNode = $session->getNode($path);
+        $path = $input->getArgument('path');
+
+        if (true === UUIDHelper::isUUID($path)) {
+            $currentNode = $session->getNodeByIdentifier($path);
+        } else {
+            $path = $session->getAbsPath($path);
+            $currentNode = $session->getNode($path);
+        }
 
         if (!$this->showChildren && !$this->showProperties) {
             $this->showChildren = true;


### PR DESCRIPTION
Enable listing node by UUID

NOTE: This change implies that we should also show the current node name somewhere in the node output.. or maybe there should just be a `node:show` command which shows all the details of a node - i.e. its path, uuid, supertrypes etc. etc.

Closes #57 
