### PR TITLE
Error on non-eistant file and expand path for profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ alpha-4
 - [args] 28 instances of bad InputArgument constructor fixed
 - [node] `node:list` Catch exceptions when rendering property rows (e.g. on invalid references)
 
+### Improvements
+
+- [connect] Always expand relative paths for `db-path`
+- [connect] Throw exception if file indicated by `db-path` does not exist.
+
 alpha-3
 -------
 

--- a/src/PHPCR/Shell/Subscriber/ProfileFromSessionInputSubscriber.php
+++ b/src/PHPCR/Shell/Subscriber/ProfileFromSessionInputSubscriber.php
@@ -38,7 +38,26 @@ class ProfileFromSessionInputSubscriber implements EventSubscriberInterface
         );
 
         foreach ($transportOptions as $optionName => $configName) {
-            $profile->set('transport', $configName, (string) $input->getOption($optionName));
+            $value = $input->getOption($optionName);
+
+            if (null !== $value) {
+                // sanitize some input values
+                switch ($optionName) {
+                    case 'db-path':
+                        if (!file_exists($value)) {
+                            throw new \InvalidArgumentException(sprintf(
+                                'DB file "%s" does not exist.'
+                            , $value));
+                        }
+
+                        $value = realpath(dirname($value)) . DIRECTORY_SEPARATOR . basename($value);
+                        break;
+                    default:
+                        // all good
+                }
+            }
+
+            $profile->set('transport', $configName, (string) $value);
         }
 
         foreach ($phpcrOptions as $optionName => $configName) {


### PR DESCRIPTION
- Throw an exception if the file specified by `db-path` does not exist.
- Always expand the path to an absolute path for storage in profile.

Closes #67 
