### PR TITLE
Prevent invalid behavior on UPDATE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ dev-master
 
 ### Bug Fixes
 
+- [query] Disabled updating multivalue properties where properties have more
+          than one value with the UPDATE, as currently other items are overwritten and
+          data is lost. See: https://github.com/phpcr/phpcr-shell/issues/85
 - [shell] Multivalue (and so multiline) property values are truncated as a single string (#70)
 
 alpha-4

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -723,6 +723,23 @@ class FeatureContext extends BehatContext
     }
 
     /**
+     * @Given /^the node at "([^"]*)" should have the property "([^"]*)" with value "([^"]*)" at index "([^"]*)"$/
+     */
+    public function theNodeAtShouldHaveThePropertyWithValueAtIndex($arg1, $arg2, $arg3, $index)
+    {
+        $session = $this->getSession();
+        $node = $session->getNode($arg1);
+        $property = $node->getProperty($arg2);
+        if (!$property->isMultiple()) {
+            throw new \Exception('Property is not multiple and you wanted to check an index');
+        }
+
+        $propertyType = $property->getValue();
+        PHPUnit_Framework_Assert::assertEquals($arg3, $propertyType[$index]);
+    }
+
+
+    /**
      * @Given /^the property "([^"]*)" should have type "([^"]*)" and value "([^"]*)"$/
      */
     public function thePropertyShouldHaveTypeAndValue($arg1, $arg2, $arg3)

--- a/features/fixtures/cms.xml
+++ b/features/fixtures/cms.xml
@@ -78,6 +78,14 @@
             <sv:property sv:name="title" sv:type="String">
                 <sv:value>Article 1</sv:value>
             </sv:property>
+            <sv:property sv:name="tags" sv:type="String" sv:multiple="true">
+                <sv:value>Planes</sv:value>
+                <sv:value>Trains</sv:value>
+                <sv:value>Automobiles</sv:value>
+            </sv:property>
+            <sv:property sv:name="tag" sv:type="String" sv:multiple="true">
+                <sv:value>Planes</sv:value>
+            </sv:property>
         </sv:node>
     </sv:node>
 </sv:node>

--- a/features/phpcr_query_update.feature
+++ b/features/phpcr_query_update.feature
@@ -7,7 +7,7 @@ Feature: Execute a a raw UPDATE query in JCR_SQL2
         Given that I am logged in as "testuser"
         And the "cms.xml" fixtures are loaded
 
-    Scenario Outline: Execute query
+    Scenario Outline: Execute update query
         Given I execute the "<query>" command
         Then the command should not fail
         And I save the session
@@ -23,3 +23,22 @@ Feature: Execute a a raw UPDATE query in JCR_SQL2
             | UPDATE nt:unstructured AS a SET a.title = 'DTL' WHERE localname() = 'article1' | /cms/articles/article1 | title | DTL |
             | UPDATE nt:unstructured AS a SET title = 'DTL' WHERE localname() = 'article1' | /cms/articles/article1 | title | DTL |
             | UPDATE nt:unstructured AS a SET title = 'DTL', foobar='barfoo' WHERE localname() = 'article1' | /cms/articles/article1 | foobar | barfoo |
+
+    Scenario: Update multivalue index by value
+        Given I execute the "UPDATE [nt:unstructured] AS a SET a.tags = 'Rockets' WHERE a.tags = 'Trains'" command
+        And I save the session
+        Then the command should not fail
+        And I should see the following:
+        """
+        Cannot update property "tags". Updating multi-value nodes with more than one element not currently supported
+        """
+
+    Scenario: Update single multivalue
+        Given I execute the "UPDATE [nt:unstructured] AS a SET a.tag = 'Rockets' WHERE a.tags = 'Planes'" command
+        And I save the session
+        Then the command should not fail
+        And I should see the following:
+        """
+        1 row(s) affected
+        """
+        And the node at "/cms/articles/article1" should have the property "tag" with value "Rockets" at index "0"

--- a/src/PHPCR/Shell/Console/Command/Phpcr/QueryUpdateCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/QueryUpdateCommand.php
@@ -52,6 +52,28 @@ EOT
             $rows++;
             foreach ($updates as $field => $property) {
                 $node = $row->getNode($property['selector']);
+
+                if ($node->hasProperty($property['name'])) {
+                    $phpcrProperty = $node->getProperty($property['name']);
+
+                    if ($phpcrProperty->isMultiple()) {
+                        $currentValue = $phpcrProperty->getValue();
+
+                        if (sizeof($currentValue) > 1) {
+                            $output->writeln(sprintf(
+                                '<error>Cannot update property "%s". Updating multi-value nodes with more than one element not currently supported</error>',
+                                $phpcrProperty->getName()
+                            ));
+                            $output->writeln(sprintf(
+                                '<error>See: https://github.com/phpcr/phpcr-shell/issues/81</error>',
+                                $phpcrProperty->getName()
+                            ));
+                        }
+
+                        $property['value'] = (array) $property['value'];
+                    }
+                }
+
                 $node->setProperty($property['name'], $property['value']);
             }
         }

--- a/src/PHPCR/Shell/Query/UpdateParser.php
+++ b/src/PHPCR/Shell/Query/UpdateParser.php
@@ -60,7 +60,7 @@ class UpdateParser extends Sql2ToQomQueryConverter
 
         $query = $this->factory->createQuery($source, $constraint);
 
-        $res = new \ArrayObject(array($query, $updates));
+        $res = new \ArrayObject(array($query, $updates, $constraint));
 
         return $res;
     }


### PR DESCRIPTION
Tests and temporary limitation to prevent data loss.
- Introduced limitation to stop people removing all mutlivalues
  unintentionally.
- UPDATE will now only update single multi-value elements until feature
  for updating indexes is implemented
