### PR TITLE
Moved the PHPCR implementations to require-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ dev-master
 
 ### Enhancements
 
+- [deps] The PHPCR implementations have been moved to require-dev
 - [exit] Ask for confirmation before logging out when there are pending changes
 
 alpha-5

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,6 @@
     "description": "Shell for PHPCR",
     "require": {
         "symfony/console": "~2.3",
-        "jackalope/jackalope-doctrine-dbal": "~1.1",
-        "jackalope/jackalope-jackrabbit": "~1.1",
         "jackalope/jackalope": "~1.1",
         "phpcr/phpcr": "~2.1",
         "phpcr/phpcr-utils": "~1.2",
@@ -14,12 +12,17 @@
     },
     "minimum-stability": "dev",
     "require-dev": {
-        "mockery/mockery": "0.9",
         "symfony/process": "~2.3",
         "symfony/filesystem": "~2.3",
         "phpunit/phpunit": "~3.7.28",
         "behat/behat": "~2.5",
-        "phpspec/phpspec": "2.0"
+        "phpspec/phpspec": "2.0",
+        "jackalope/jackalope-doctrine-dbal": "~1.1",
+        "jackalope/jackalope-jackrabbit": "~1.1"
+    },
+    "suggest": {
+        "jackalope/jackalope-doctrine-dbal": "To connect to jackalope doctrine-dbal",
+        "jackalope/jackalope-doctrine-dbal": "To connect to jackalope jackrabbit"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
The standalone version is always compiled in a dev environment. The
implementatoins are now only in require-dev allowing the phpcr-shell to
be dependend on without pulling in extra implementations.
