### PR TITLE
Fixed behavior of node:references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+dev-master
+----------
+
+- [node:references] Shows the referencing node paths instead of the referrered-to node path(s)
+
 alpha-6
 -------
 

--- a/features/phpcr_node_references.feature
+++ b/features/phpcr_node_references.feature
@@ -13,8 +13,8 @@ Feature: Show node references
         Then the command should not fail
         And I should see a table containing the following rows:
             | Type | Property | Node Path                                                      |
-            | weak | ref2     | /tests_general_base/idExample/jcr:content/weakreference_target |
-            | weak | ref1     | /tests_general_base/idExample/jcr:content/weakreference_target |
+            | weak | ref2     | /tests_general_base/idExample/jcr:content/weakreference_source2 |
+            | weak | ref1     | /tests_general_base/idExample/jcr:content/weakreference_source1 |
 
     Scenario: List named weak references
         Given the current node is "/tests_general_base/idExample/jcr:content/weakreference_target"
@@ -22,7 +22,7 @@ Feature: Show node references
         Then the command should not fail
         And I should see a table containing the following rows:
             | Type | Property | Node Path                                                      |
-            | weak | ref2     | /tests_general_base/idExample/jcr:content/weakreference_target |
+            | weak | ref2     | /tests_general_base/idExample/jcr:content/weakreference_source2 |
 
     Scenario: List strong references
         Given the current node is "/tests_general_base/idExample"
@@ -30,6 +30,6 @@ Feature: Show node references
         Then the command should not fail
         And I should see a table containing the following rows:
             | Type   | Property | Node Path                              |
-            | strong | ref      | /tests_general_base/idExample          |
-            | strong | multiref | /tests_general_base/idExample          |
-            |        |          | /tests_general_base/multiValueProperty |
+            | strong | ref      | /tests_general_base/numberPropertyNode/jcr:content |
+            | strong | multiref | /tests_general_base/numberPropertyNode/jcr:content |
+

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeReferencesCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeReferencesCommand.php
@@ -59,22 +59,12 @@ HERE
 
         foreach ($references as $type => $typeReferences) {
             foreach ($typeReferences as $property) {
-                if ($property->isMultiple()) {
-                    $nodes = $property->getNode();
-                } else {
-                    $nodes = array($property->getNode());
-                }
-
-                $nodePaths = array();
-
-                foreach ($nodes as $node) {
-                    $nodePaths[] = $node->getPath();
-                }
+                $nodePath = $property->getParent()->getPath();
 
                 $table->addRow(array(
                     $type,
                     $property->getName(),
-                    implode("\n", $nodePaths),
+                    $nodePath
                 ));
             }
         }


### PR DESCRIPTION
It was showing the paths to the referenced properties not the paths to
the referring nodes.
