### PR TITLE
Renamed session import/export commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ dev-master
 ----------
 
 - [references] Show UUIDs when listing reference properties
+- [import/export] Renamed session import and export to `session:import` &
+  `session:export`
 - [transport] Added transport layer for experimental Jackalope FS implementation
 - [misc] Wildcard (single asterisk) support in paths
 - [node] Added wilcard support to applicable node commands, including "node:list", "node:remove" and "node:property:show"

--- a/features/all/phpcr_session_export.feature
+++ b/features/all/phpcr_session_export.feature
@@ -1,7 +1,7 @@
 Feature: Export the repository to an XML file
     In order to export the repository (or part of the repository) to an XML file
     As a user that is logged into the shell
-    I want to be able to "session:export:view" command to export the repository to an XML file.
+    I want to be able to "session:export" command to export the repository to an XML file.
 
     Background:
         Given that I am logged in as "testuser"
@@ -9,19 +9,19 @@ Feature: Export the repository to an XML file
         And the "session_data.xml" fixtures are loaded
 
     Scenario: Export the root
-        Given I execute the "session:export:view / foobar.xml" command
+        Given I execute the "session:export / foobar.xml" command
         Then the command should not fail
         And the file "foobar.xml" should exist
         And the xpath count "/sv:node" is "1" in file "foobar.xml"
         And the xpath count "/sv:node/sv:node" is "1" in file "foobar.xml"
 
     Scenario: Export a subtree
-        Given I execute the "session:export:view /tests_general_base foobar.xml" command
+        Given I execute the "session:export /tests_general_base foobar.xml" command
         Then the file "foobar.xml" should exist
         And the command should not fail
 
     Scenario: Export with an invalid path
-        Given I execute the "session:export:view cms foobar.xml" command
+        Given I execute the "session:export cms foobar.xml" command
         Then the command should fail
         And the output should contain:
         """
@@ -30,26 +30,26 @@ Feature: Export the repository to an XML file
 
     Scenario: Export to an existing file (should overwrite as --no-interaction is specified)
         Given the file "foobar.xml" exists
-        And I execute the "session:export:view /tests_general_base foobar.xml --no-interaction" command
+        And I execute the "session:export /tests_general_base foobar.xml --no-interaction" command
         Then the command should not fail
 
     Scenario: Export non recursive
-        Given I execute the "session:export:view /tests_general_base foobar.xml --no-recurse" command
+        Given I execute the "session:export /tests_general_base foobar.xml --no-recurse" command
         Then the command should not fail
         And the file "foobar.xml" should exist
         And the xpath count "/sv:node" is "1" in file "foobar.xml"
         And the xpath count "/sv:node/sv:node" is "0" in file "foobar.xml"
 
     Scenario: Export and skip binaries
-        Given I execute the "session:export:view / foobar.xml --skip-binary" command
+        Given I execute the "session:export / foobar.xml --skip-binary" command
         Then the command should not fail
 
     Scenario: Export the document view
-        Given I execute the "session:export:view / foobar.xml --document" command
+        Given I execute the "session:export / foobar.xml --document" command
         Then the command should not fail
 
     Scenario: Export the document view in pretty way
-        Given I execute the "session:export:view / foobar.xml --pretty" command
+        Given I execute the "session:export / foobar.xml --pretty" command
         Then the command should not fail
         And the file "foobar.xml" should exist
         And the xpath count "/sv:node" is "1" in file "foobar.xml"

--- a/src/PHPCR/Shell/Console/Application/ShellApplication.php
+++ b/src/PHPCR/Shell/Console/Application/ShellApplication.php
@@ -108,9 +108,9 @@ class ShellApplication extends Application
         // phpcr commands
         $this->add(new CommandPhpcr\AccessControlPrivilegeListCommand());
         $this->add(new CommandPhpcr\RepositoryDescriptorListCommand());
-        $this->add(new CommandPhpcr\SessionExportViewCommand());
+        $this->add(new CommandPhpcr\SessionExportCommand());
         $this->add(new CommandPhpcr\SessionImpersonateCommand());
-        $this->add(new CommandPhpcr\SessionImportXMLCommand());
+        $this->add(new CommandPhpcr\SessionImportCommand());
         $this->add(new CommandPhpcr\SessionInfoCommand());
         $this->add(new CommandPhpcr\SessionNamespaceListCommand());
         $this->add(new CommandPhpcr\SessionNamespaceSetCommand());

--- a/src/PHPCR/Shell/Console/Command/Phpcr/SessionExportCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/SessionExportCommand.php
@@ -9,12 +9,12 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use PHPCR\Util\PathHelper;
 
-class SessionExportViewCommand extends BasePhpcrCommand
+class SessionExportCommand extends BasePhpcrCommand
 {
     protected function configure()
     {
-        $this->setName('session:export:view');
-        $this->setDescription('Export the system view');
+        $this->setName('session:export');
+        $this->setDescription('Export the to XML');
         $this->addArgument('absPath', InputArgument::REQUIRED, 'Path of node to export');
         $this->addArgument('file', InputArgument::REQUIRED, 'File to export to');
         $this->addOption('no-recurse', null, InputOption::VALUE_NONE, 'Do not recurse');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/SessionImportCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/SessionImportCommand.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use PHPCR\Util\PathHelper;
 
-class SessionImportXMLCommand extends BasePhpcrCommand
+class SessionImportCommand extends BasePhpcrCommand
 {
     protected $uuidBehaviors = array(
         'create-new',
@@ -20,10 +20,10 @@ class SessionImportXMLCommand extends BasePhpcrCommand
 
     protected function configure()
     {
-        $this->setName('session:import-xml');
+        $this->setName('session:import');
         $this->setDescription('Import content from an XML file');
         $this->addArgument('parentAbsPath', InputArgument::REQUIRED, 'Path of node to export');
-        $this->addArgument('file', InputArgument::REQUIRED, 'File to export to');
+        $this->addArgument('file', InputArgument::REQUIRED, 'File to import from');
         $this->addOption('uuid-behavior', null, InputOption::VALUE_REQUIRED, 'UUID behavior', 'create-new');
         $this->setHelp(<<<HERE
 Deserializes an XML document and adds the resulting item subgraph as a


### PR DESCRIPTION
Renamed session import / export to `session:import` and `session:export`. Fixed typo
