### PR TITLE
Query update APPLY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ dev-master
 
 ### Features
 
+- [query:update] Added APPLY method to queries.
+- [query:update] APPLY `mixin_add` and `mixin_remove` functions
 - [node:remove] Immediately fail when trying to delete a node which has a
   (hard) referrer
 - [cli] Specify workspace with first argument

--- a/features/all/phpcr_node_edit.feature
+++ b/features/all/phpcr_node_edit.feature
@@ -106,11 +106,11 @@ Feature: Edit a node
             type: String
             value: 'FOOOOOOO'
         """
-        And I execute the "node:edit cms/products/product2" command
+        And I execute the "node:edit cms/products/productx" command
         Then the command should not fail
         And I save the session
         Then the command should not fail
-        And the property "/cms/products/product2/foobar" should have type "String" and value "FOOOOOOO"
+        And the property "/cms/products/productx/foobar" should have type "String" and value "FOOOOOOO"
 
     Scenario: Create a new node with short syntax
         Given I have an editor which produces the following:
@@ -120,11 +120,11 @@ Feature: Edit a node
             value: 'nt:unstructured'
         foobar: FOOOOOOO
         """
-        And I execute the "node:edit cms/products/product2" command
+        And I execute the "node:edit cms/products/productx" command
         Then the command should not fail
         And I save the session
         Then the command should not fail
-        And the property "/cms/products/product2/foobar" should have type "String" and value "FOOOOOOO"
+        And the property "/cms/products/productx/foobar" should have type "String" and value "FOOOOOOO"
 
     Scenario: Create a new node with a specified type
         Given I have an editor which produces the following:
@@ -136,18 +136,18 @@ Feature: Edit a node
             type: Binary
             value: foo
         """
-        And I execute the "node:edit cms/products/product2 --type=nt:resource" command
+        And I execute the "node:edit cms/products/productx --type=nt:resource" command
         Then the command should not fail
         And I save the session
         Then the command should not fail
-        And there should exist a node at "/cms/products/product2"
-        And the primary type of "/cms/products/product2" should be "nt:resource"
+        And there should exist a node at "/cms/products/productx"
+        And the primary type of "/cms/products/productx" should be "nt:resource"
 
     Scenario: Editor returns empty string
         Given I have an editor which produces the following:
         """"
         """
-        And I execute the "node:edit cms/products/product2 --no-interaction --type=nt:resource" command
+        And I execute the "node:edit cms/products/productx --no-interaction --type=nt:resource" command
         Then the command should fail
 
     Scenario: Edit a node by UUID

--- a/features/all/phpcr_query_update.feature
+++ b/features/all/phpcr_query_update.feature
@@ -113,10 +113,30 @@ Feature: Execute a a raw UPDATE query in JCR_SQL2
         [PHPCR\PathNotFoundException] Property 10
         """
 
-    Scenario: Replace a multivalue property by invalid index with array (invalid)
-        Given I execute the "UPDATE [nt:unstructured] AS a SET a.tags = array_replace_at(a.tags, 0, array('Kite')) WHERE a.tags = 'Planes'" command
-        Then the command should fail
-        And I should see the following:
-        """
-        Cannot use an array as a value in a multivalue property
-        """
+    Scenario: Apply mixin_remove
+        Given I execute the "UPDATE [nt:unstructured] AS a APPLY mixin_remove('mix:title') WHERE a.name = 'Product Two'" command
+        Then the command should not fail
+        And I save the session
+        Then the command should not fail
+        Then the node at "/cms/products/product2" should not have the mixin "mix:title"
+
+    Scenario: Apply mixin_add
+        Given I execute the "UPDATE [nt:unstructured] AS a APPLY mixin_add('mix:mimeType') WHERE a.tags = 'Planes'" command
+        Then the command should not fail
+        And I save the session
+        And the node at "/cms/articles/article1" should have the mixin "mix:mimeType"
+
+    Scenario: Apply mixin_add existing
+        Given I execute the "UPDATE [nt:unstructured] AS a APPLY mixin_add('mix:title') WHERE a.name = 'Product Two'" command
+        Then the command should not fail
+        And I save the session
+        Then the command should not fail
+        Then the node at "/cms/products/product2" should have the mixin "mix:title"
+
+    Scenario: Apply multiple functions
+        Given I execute the "UPDATE [nt:unstructured] AS a APPLY mixin_add('mix:mimeType'), mixin_add('mix:lockable') WHERE a.tags = 'Planes'" command
+        Then the command should not fail
+        And I save the session
+        And the node at "/cms/articles/article1" should have the mixin "mix:mimeType"
+        Then the node at "/cms/articles/article1" should have the mixin "mix:lockable"
+

--- a/features/fixtures/cms.xml
+++ b/features/fixtures/cms.xml
@@ -58,6 +58,17 @@
                 <sv:value>99999999-1abf-4708-bfcc-e49511754b40</sv:value>
             </sv:property>
         </sv:node>
+        <sv:node sv:name="product2">
+            <sv:property sv:name="jcr:primaryType" sv:type="Name">
+                <sv:value>nt:unstructured</sv:value>
+            </sv:property>
+            <sv:property sv:name="jcr:mixinTypes" sv:type="name">
+                <sv:value>mix:title</sv:value>
+            </sv:property>
+            <sv:property sv:name="name" sv:type="String">
+                <sv:value>Product Two</sv:value>
+            </sv:property>
+        </sv:node>
     </sv:node>
 
     <sv:node sv:name="users">

--- a/spec/PHPCR/Shell/Query/UpdateParserSpec.php
+++ b/spec/PHPCR/Shell/Query/UpdateParserSpec.php
@@ -94,4 +94,22 @@ EOT;
 
         $res->offsetGet(0)->shouldHaveType('PHPCR\Query\QueryInterface');
     }
+
+    public function it_should_parse_apply (
+        QueryObjectModelFactoryInterface $qomf,
+        SourceInterface $source,
+        QueryInterface $query
+    )
+    {
+        $qomf->selector('a', 'dtl:article')->willReturn($source);
+        $qomf->createQuery($source, null)->willReturn($query);
+
+
+        $sql = <<<EOT
+UPDATE [dtl:article] AS a APPLY nodetype_add('nt:barbar')
+EOT;
+        $res = $this->parse($sql);
+
+        $res->offsetGet(0)->shouldHaveType('PHPCR\Query\QueryInterface');
+    }
 }

--- a/src/PHPCR/Shell/Console/Command/Phpcr/QueryUpdateCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/QueryUpdateCommand.php
@@ -74,6 +74,7 @@ EOT
         $res = $updateParser->parse($sql);
         $query = $res->offsetGet(0);
         $updates = $res->offsetGet(1);
+        $applies = $res->offsetGet(3);
 
         $start = microtime(true);
         $result = $query->execute();
@@ -84,7 +85,11 @@ EOT
         foreach ($result as $row) {
             $rows++;
             foreach ($updates as $property) {
-                $updateProcessor->updateNode($row, $property);
+                $updateProcessor->updateNodeSet($row, $property);
+            }
+
+            foreach ($applies as $apply) {
+                $updateProcessor->updateNodeApply($row, $apply);
             }
         }
 

--- a/src/PHPCR/Shell/Query/FunctionOperand.php
+++ b/src/PHPCR/Shell/Query/FunctionOperand.php
@@ -60,6 +60,7 @@ class FunctionOperand
 
         $callable = $functionMap[$functionName];
         $args = $this->getArguments();
+        array_unshift($args, $row);
         array_unshift($args, $this);
         $value = call_user_func_array($callable, $args);
 

--- a/src/PHPCR/Shell/Test/ContextBase.php
+++ b/src/PHPCR/Shell/Test/ContextBase.php
@@ -218,6 +218,7 @@ abstract class ContextBase implements Context, SnippetAcceptingContext
         NodeHelper::purgeWorkspace($session);
         $session->save();
 
+
         // shouldn't have to do this, but this seems to be a bug in jackalope
         $session->refresh(false);
 


### PR DESCRIPTION
- Allow applying a function to result sets
- Added apply functions "mixin_add" and "mixin_remove"

```
PHPCRSH> UPDATE [nt:unstructured] APPLY mixin_add('mix:foobar'), mixin_remove('bar:foo')
```

Fixes #99 

Other things we could add:
- `lock`: Lock the node
- `primary_type`: Set primary type
- `lock_refresh`
- `lock_token_add`
- `lock_token_remove`
- `unlock`
- `lifecycle_follow`
- `property_set`: Alternative to `SET a = b`
- `retention_hold_add`
- `retention_hold_remove`
