### PR TITLE
Improved autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,23 +10,24 @@ dev-master
 - [node:remove] Cannot `node:remove` by UUID
 - [node:edit] Serialization of single value references doesn't work
 
-### Features
+### Enhancements
 
-- [query:update] Added APPLY method to queries.
-- [query:update] APPLY `mixin_add` and `mixin_remove` functions
-- [node:remove] Immediately fail when trying to delete a node which has a
-  (hard) referrer
-- [cli] Specify workspace with first argument
-- [global] Refactored to use DI container and various general improvements
-- [node:property:set] Allow setting reference property type by path
+- [autocomplete] Autocomplete now includes command names
 - [references] Show UUIDs when listing reference properties
 - [import/export] Renamed session import and export to `session:import` &
-  `session:export`
+
+### Features
+
+- [cli] Specify workspace with first argument
 - [config] Added user config for general settings
 - [config] Enable / disable showing execution times and set decimal expansion
-- [transport] Added transport layer for experimental Jackalope FS implementation
-- [node] Added wilcard support to applicable node commands, including "node:list", "node:remove" and "node:property:show"
+- [global] Refactored to use DI container and various general improvements
+- [node:property:set] Allow setting reference property type by path`session:export`
 - [node:references] Shows the referencing node paths instead of the referrered-to node path(s)
+- [node:remove] Immediately fail when trying to delete a node which has a (hard) referrer
+- [node] Added wilcard support to applicable node commands, including "node:list", "node:remove" and "node:property:show"
+- [query:update] Added APPLY method to queries, permits addition and removal of mixins
+- [transport] Added transport layer for experimental Jackalope FS implementation
 
 alpha-6
 -------

--- a/src/PHPCR/Shell/Console/Application/EmbeddedApplication.php
+++ b/src/PHPCR/Shell/Console/Application/EmbeddedApplication.php
@@ -49,17 +49,11 @@ class EmbeddedApplication extends ShellApplication
      */
     public function init()
     {
-        if (true === $this->initialized) {
-            return;
-        }
-
         $this->registerPhpcrCommands();
 
         if ($this->container->getMode() === self::MODE_SHELL) {
             $this->registerShellCommands();
         }
-
-        $this->initialized = true;
     }
 
     /**

--- a/src/PHPCR/Shell/Console/Application/SessionApplication.php
+++ b/src/PHPCR/Shell/Console/Application/SessionApplication.php
@@ -30,7 +30,7 @@ class SessionApplication extends BaseApplication
         parent::__construct(self::APP_NAME, self::APP_VERSION);
 
         $container = new Container();
-        $this->shellApplication = new ShellApplication($container);
+        $this->shellApplication = $container->get('console.application.shell');
 
         $command = new ShellCommand($this->shellApplication);
         $command->setApplication($this);

--- a/src/PHPCR/Shell/Console/Application/Shell.php
+++ b/src/PHPCR/Shell/Console/Application/Shell.php
@@ -103,10 +103,12 @@ EOF;
      */
     private function autocompleter($text)
     {
-        $info = readline_info();
-        $text = substr($info['line_buffer'], 0, $info['end']);
-        $list = $this->application->getContainer()->get('phpcr.session')->autocomplete($text);
-
+        // the following does not work at all on my system
+        // it only returns the previous line:
+        //
+        // $info = readline_info();
+        // $text = substr($info['line_buffer'], 0, $info['end']);
+        $list = $this->application->getContainer()->get('console.input.autocomplete')->autocomplete('');
         return $list;
     }
 

--- a/src/PHPCR/Shell/Console/Application/ShellApplication.php
+++ b/src/PHPCR/Shell/Console/Application/ShellApplication.php
@@ -29,13 +29,6 @@ use PHPCR\Shell\Config\Profile;
 class ShellApplication extends Application
 {
     /**
-     * True when application has been initialized once
-     *
-     * @var boolean
-     */
-    protected $initialized;
-
-    /**
      * @var boolean
      */
     protected $showUnsupported = false;
@@ -61,6 +54,7 @@ class ShellApplication extends Application
         $this->dispatcher = $container->get('event.dispatcher') ? : new EventDispatcher();
         $this->setDispatcher($this->dispatcher);
         $this->container = $container;
+        $this->init();
     }
 
     /**
@@ -75,29 +69,16 @@ class ShellApplication extends Application
     }
 
     /**
-     * Initialize the application.
-     *
-     * Note that we do this "lazily" because we instantiate the ShellApplication early,
-     * before the SessionInput has been set. The SessionInput must be set before we
-     * can initialize the application.
-     *
-     * @todo: The above scenario is no longer true, we use a Profile. So maybe it can
-     *        be refactored.
+     * Initialize the application
      */
     public function init()
     {
-        if (true === $this->initialized) {
-            return;
-        }
-
         $this->registerPhpcrCommands();
         $this->registerPhpcrStandaloneCommands();
         $this->registerShellCommands();
 
         $event = new ApplicationInitEvent($this);
         $this->dispatcher->dispatch(PhpcrShellEvents::APPLICATION_INIT, $event);
-
-        $this->initialized = true;
     }
 
     /**
@@ -236,8 +217,6 @@ class ShellApplication extends Application
      */
     public function doRun(InputInterface $input, OutputInterface $output)
     {
-        $this->init();
-
         // configure the formatter for the output
         $this->configureFormatter($output->getFormatter());
 

--- a/src/PHPCR/Shell/Console/Input/AutoComplete.php
+++ b/src/PHPCR/Shell/Console/Input/AutoComplete.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace PHPCR\Shell\Console\Input;
+
+use PHPCR\Shell\Console\Application\ShellApplication;
+use PHPCR\Shell\Phpcr\PhpcrSession;
+
+/**
+ * Class for autocompleting commands
+ *
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+class AutoComplete
+{
+    private $application;
+    private $session;
+
+    public function __construct(ShellApplication $application, PhpcrSession $session)
+    {
+        $this->application = $application;
+        $this->session = $session;
+    }
+
+    public function autocomplete($text)
+    {
+        $list = array_keys($this->application->all());
+
+        $node = $this->session->getCurrentNode();
+
+        foreach ($node->getNodes() as $node) {
+            $list[] = $node->getName();
+        }
+
+        foreach ($node->getProperties() as $property) {
+            $list[] = $property->getName();
+        }
+
+        return $list;
+    }
+}

--- a/src/PHPCR/Shell/DependencyInjection/Container.php
+++ b/src/PHPCR/Shell/DependencyInjection/Container.php
@@ -27,10 +27,13 @@ class Container extends ContainerBuilder
         parent::__construct();
         $this->mode = $mode;
 
+        $this->set('container', $this);
+
         $this->registerHelpers();
         $this->registerConfig();
         $this->registerPhpcr();
         $this->registerEvent();
+        $this->registerConsole();
     }
 
     public function registerHelpers()
@@ -141,6 +144,15 @@ class Container extends ContainerBuilder
         foreach (array_keys($this->findTaggedServiceIds('event.subscriber')) as $id) {
             $dispatcher->addMethodCall('addSubscriber', array(new Reference($id)));
         }
+    }
+
+    public function registerConsole()
+    {
+        $this->register('console.application.shell', 'PHPCR\Shell\Console\Application\ShellApplication')
+            ->addArgument(new Reference('container'));
+        $this->register('console.input.autocomplete', 'PHPCR\Shell\Console\Input\AutoComplete')
+            ->addArgument(new Reference('console.application.shell'))
+            ->addArgument(new Reference('phpcr.session'));
     }
 
     public function getMode()


### PR DESCRIPTION
The autocomplete now includes commands in addition to paths and
options.

I was hoping to improve this to support `full/path/au<tab>/completion` however the `readline_info` command does not return the current line buffer as documented (it returns the last line). Without this I can only retrieve the last segment of the line buffer (e.g. `completion`).

I notice also that the Symfony shell uses the same method that I tried to use, and that also does not work.

I wonder if I could do something closer to the metal, e.g. [like this pr](https://github.com/symfony/symfony/pull/6391/files) but for the minute this is OK.
