### PR TITLE
Load the profile after setting the config from the Input

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
     - 5.4
 
 before_script:
+    - composer self-update
     - composer require "symfony/symfony" "2.6.*" --no-update
     - composer install
     - bash tests/bin/travis_jackrabbit.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ dev-master
 ### Bug fixes
 
 - [embedded] No exit code returned
+- [profile] Profile configuration overwritten by session parameters
 
 beta1
 -----

--- a/behat.yml
+++ b/behat.yml
@@ -14,3 +14,8 @@ default:
                 - PHPCR\Shell\Test\EmbeddedContext
             paths:
                 - features/all
+        cli:
+            contexts:
+                - PHPCR\Shell\Test\CliContext
+            paths:
+                - features/cli

--- a/features/all/phpcr_node_edit.feature
+++ b/features/all/phpcr_node_edit.feature
@@ -7,7 +7,7 @@ Feature: Edit a node
         Given that I am logged in as "testuser"
         And the "cms.xml" fixtures are loaded
 
-    Scenario: Make a nutral edit
+    Scenario: Make a neutral edit
         Given I have an editor which produces the following:
         """"
         weight:
@@ -91,7 +91,7 @@ Feature: Edit a node
         And I save the session
         Then the command should not fail
         And the property "/cms/products/product1/weight" should have type "Long" and value "10"
-        And the property "/cms/products/product1/cost" should have type "Long" and value "100"
+        And the property "/cms/products/product1/cost" should have type "Double" and value "100"
         And the property "/cms/products/product1/size" should have type "String" and value "XXL"
         And the property "/cms/products/product1/name" should have type "String" and value "Product One"
         And the property "/cms/products/product1/jcr:primaryType" should have type "Name" and value "nt:unstructured"

--- a/features/cli/doctrine-dbal.feature
+++ b/features/cli/doctrine-dbal.feature
@@ -1,0 +1,31 @@
+Feature: Connect to a doctrine dbal repository
+    In order to use the jackalope doctrine-dbal repository
+    As a user
+    I need to be able to connect to it
+
+    Background:
+        Given I initialize doctrine dbal
+
+    Scenario: Connect to doctrine-dbal session
+        Given I run PHPCR shell with "--transport=doctrine-dbal --db-driver=pdo_sqlite --db-path=./app.sqlite --command='ls'"
+        Then the command should not fail
+
+    Scenario: Connect to doctrine-dbal session create a new profile
+        Given I run PHPCR shell with "--transport=doctrine-dbal --db-driver=pdo_sqlite --db-path=./app.sqlite --profile=new --no-interaction --command='ls'"
+        Then the command should not fail
+
+    Scenario: Connect to an existing profile
+        Given the following profile "phpcrtest" exists:
+        """
+        transport:
+            name: doctrine-dbal
+            db_name: phpcrtest
+            db_path: app.sqlite
+            db_driver: pdo_sqlite
+        phpcr:
+            workspace: default
+            username: admin
+            password: admin
+        """
+        And I run PHPCR shell with "--profile=phpcrtest --no-interaction --command='ls'"
+        Then the command should not fail

--- a/features/fixtures/jackalope-doctrine-dbal-cli-config.php
+++ b/features/fixtures/jackalope-doctrine-dbal-cli-config.php
@@ -1,0 +1,39 @@
+<?php
+$dbConn = \Doctrine\DBAL\DriverManager::getConnection(array(
+    'driver'    => 'pdo_sqlite',
+    'dbname'    => 'test',
+    'path'      => __DIR__.'/app.sqlite',
+));
+
+/*
+ * configuration
+ */
+$workspace  = 'default'; // phpcr workspace to use
+$user       = 'admin';
+$pass       = 'admin';
+
+$factory = new \Jackalope\RepositoryFactoryDoctrineDBAL();
+$repository = $factory->getRepository(array('jackalope.doctrine_dbal_connection' => $dbConn));
+
+$credentials = new \PHPCR\SimpleCredentials($user, $pass);
+
+/* only create a session if this is not about the server control command */
+if (isset($argv[1])
+    && $argv[1] != 'jackalope:init:dbal'
+    && $argv[1] != 'list'
+    && $argv[1] != 'help'
+) {
+    $session = $repository->login($credentials, $workspace);
+
+    $helperSet = new \Symfony\Component\Console\Helper\HelperSet(array(
+        'dialog' => new \Symfony\Component\Console\Helper\DialogHelper(),
+        'phpcr' => new \PHPCR\Util\Console\Helper\PhpcrHelper($session),
+        'phpcr_console_dumper' => new \PHPCR\Util\Console\Helper\PhpcrConsoleDumperHelper(),
+    ));
+} else if (isset($argv[1]) && $argv[1] == 'jackalope:init:dbal') {
+    // special case: the init command needs the db connection, but a session is impossible if the db is not yet initialized
+    $helperSet = new \Symfony\Component\Console\Helper\HelperSet(array(
+        'connection' => new \Jackalope\Tools\Console\Helper\DoctrineDbalHelper($dbConn)
+    ));
+}
+

--- a/spec/PHPCR/Shell/Config/ProfileSpec.php
+++ b/spec/PHPCR/Shell/Config/ProfileSpec.php
@@ -12,6 +12,7 @@
 namespace spec\PHPCR\Shell\Config;
 
 use PhpSpec\ObjectBehavior;
+use PHPCR\Shell\Config\Config;
 
 class ProfileSpec extends ObjectBehavior
 {
@@ -39,9 +40,7 @@ class ProfileSpec extends ObjectBehavior
             'foo' => 'bar'
         ));
 
-        $this->get('transport')->shouldReturn(array(
-            'foo' => 'bar'
-        ));
+        $this->get('transport')->shouldHaveType('PHPCR\Shell\Config\Config');
 
         $this->get('transport', 'foo')->shouldReturn('bar');
     }

--- a/src/PHPCR/Shell/Config/Profile.php
+++ b/src/PHPCR/Shell/Config/Profile.php
@@ -80,7 +80,7 @@ class Profile
         $this->validateDomain($domain);
 
         if (null === $key) {
-            return $this->profile[$domain];
+            return new Config($this->profile[$domain]);
         }
 
         if (!isset($this->profile[$domain][$key])) {

--- a/src/PHPCR/Shell/DependencyInjection/Container.php
+++ b/src/PHPCR/Shell/DependencyInjection/Container.php
@@ -105,17 +105,17 @@ class Container extends ContainerBuilder
     {
         if ($this->mode === PhpcrShell::MODE_STANDALONE) {
             $this->register(
+                'event.subscriber.profile_from_session_input',
+                'PHPCR\Shell\Subscriber\ProfileFromSessionInputSubscriber'
+            )->addTag('event.subscriber');
+
+            $this->register(
                 'event.subscriber.profile_loader',
                 'PHPCR\Shell\Subscriber\ProfileLoaderSubscriber'
             )
                 ->addArgument(new Reference('config.profile_loader'))
                 ->addArgument(new Reference('helper.question'))
                 ->addTag('event.subscriber');
-
-            $this->register(
-                'event.subscriber.profile_from_session_input',
-                'PHPCR\Shell\Subscriber\ProfileFromSessionInputSubscriber'
-            )->addTag('event.subscriber');
 
             $this->register(
                 'event.subscriber.profile_writer',

--- a/src/PHPCR/Shell/Subscriber/ProfileWriterSubscriber.php
+++ b/src/PHPCR/Shell/Subscriber/ProfileWriterSubscriber.php
@@ -40,6 +40,7 @@ class ProfileWriterSubscriber implements EventSubscriberInterface
         $profile = $e->getProfile();
         $input = $e->getInput();
         $output = $e->getOutput();
+        $noInteraction = $input->getOption('no-interaction');
         $transport = $input->getOption('transport');
         $profileName = $input->getOption('profile');
 
@@ -50,10 +51,17 @@ class ProfileWriterSubscriber implements EventSubscriberInterface
             $overwrite = false;
 
             if (file_exists($this->profileLoader->getProfilePath($profileName))) {
-                $res = $this->questionHelper->askConfirmation($output, sprintf('Update existing profile "%s"?', $profileName));
+                $res = true;
+                if (false === $noInteraction) {
+                    $res = $this->questionHelper->askConfirmation($output, sprintf('Update existing profile "%s"?', $profileName));
+                }
                 $overwrite = true;
             } else {
-                $res = $this->questionHelper->askConfirmation($output, sprintf('Create new profile "%s"?', $profileName));
+                $res = true;
+
+                if (false === $noInteraction) {
+                    $res = $this->questionHelper->askConfirmation($output, sprintf('Create new profile "%s"?', $profileName));
+                }
             }
 
             if ($res) {

--- a/src/PHPCR/Shell/Test/CliContext.php
+++ b/src/PHPCR/Shell/Test/CliContext.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of the PHPCR Shell package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPCR\Shell\Test;
+
+use Jackalope\RepositoryFactoryJackrabbit;
+use PHPCR\SimpleCredentials;
+use PHPCR\Util\NodeHelper;
+use Symfony\Component\Filesystem\Filesystem;
+use PHPCR\PathNotFoundException;
+use PHPCR\Util\PathHelper;
+use PHPCR\PropertyInterface;
+use PHPCR\PropertyType;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Behat\Context\Context;
+use PHPCR\NodeInterface;
+use Behat\Gherkin\Node\PyStringNode;
+use Behat\Gherkin\Node\TableNode;
+
+/**
+ * Features context.
+ */
+class CliContext implements Context, SnippetAcceptingContext
+{
+    private $output = array();
+    private $rootPath;
+    private $lastExitCode;
+    private $fixturesDir;
+
+    /**
+     * Initializes context.
+     * Every scenario gets it's own context object.
+     *
+     * @BeforeScenario
+     */
+    public function beforeScenario()
+    {
+        $this->output = array();
+
+        $this->rootPath = realpath(__DIR__ . '/../../../..');
+        $dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'phpcr-shell' . DIRECTORY_SEPARATOR .
+            md5(microtime() * rand(0, 10000));
+        $this->fixturesDir = realpath(__DIR__.'/../../../../features/fixtures/');
+
+        $this->workingDir = $dir;
+        putenv('PHPCRSH_HOME=' . $dir);
+
+        mkdir($this->workingDir, 0777, true);
+        mkdir($this->workingDir . '/profiles');
+        chdir($this->workingDir);
+        $this->filesystem = new Filesystem();
+    }
+
+    /**
+     * Cleans test folders in the temporary directory.
+     *
+     * @AfterSuite
+     */
+    public static function cleanTestFolders()
+    {
+        $fs = new Filesystem();
+        $fs->remove(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'phpcr-shell');
+    }
+
+    private function exec($command)
+    {
+        exec($command, $output, $return);
+        $this->output += $output;
+        $this->lastExitCode = $return;
+    }
+
+    /**
+     * @Given I run PHPCR shell with ":argsAndOptions"
+     */
+    public function execShell($argsAndOptions)
+    {
+        $this->exec(sprintf('%s/bin/phpcrsh %s', $this->rootPath, $argsAndOptions));
+    }
+
+    /**
+     * @Given print output
+     */
+    public function printOutput()
+    {
+        foreach ($this->output as $line) {
+            echo $line . PHP_EOL;
+        }
+    }
+
+    /**
+     * @Given the following profile ":profileName" exists:
+     */
+    public function iHaveTheFollowingProfile($profileName, PyStringNode $text)
+    {
+        file_put_contents($this->workingDir . '/profiles/' . $profileName . '.yml', $text->getRaw());
+    }
+
+    /**
+     * @Given I initialize doctrine dbal
+     */
+    public function initializeDoctrineDbal()
+    {
+        $this->filesystem->copy(
+            $this->fixturesDir . '/jackalope-doctrine-dbal-cli-config.php',
+            $this->workingDir . '/cli-config.php'
+        );
+        $this->exec($this->rootPath . '/vendor/jackalope/jackalope-doctrine-dbal/bin/jackalope jackalope:init:dbal --force');
+    }
+
+    /**
+     * @Then the command should not fail
+     */
+    public function theCommandShouldNotFail()
+    {
+        \PHPUnit_Framework_Assert::assertEquals(0, $this->lastExitCode);
+    }
+}

--- a/src/PHPCR/Shell/Transport/Transport/DoctrineDbal.php
+++ b/src/PHPCR/Shell/Transport/Transport/DoctrineDbal.php
@@ -14,6 +14,7 @@ namespace PHPCR\Shell\Transport\Transport;
 use Doctrine\DBAL\DriverManager;
 use Jackalope\RepositoryFactoryDoctrineDBAL;
 use PHPCR\Shell\Transport\TransportInterface;
+use PHPCR\Shell\Config\Config;
 
 class DoctrineDbal implements TransportInterface
 {
@@ -22,7 +23,7 @@ class DoctrineDbal implements TransportInterface
         return 'doctrine-dbal';
     }
 
-    public function getRepository(array $config)
+    public function getRepository(Config $config)
     {
         $connection = DriverManager::getConnection($ops = array(
             'user' => $config['db_username'],

--- a/src/PHPCR/Shell/Transport/Transport/JackalopeFs.php
+++ b/src/PHPCR/Shell/Transport/Transport/JackalopeFs.php
@@ -13,6 +13,7 @@ namespace PHPCR\Shell\Transport\Transport;
 
 use PHPCR\Shell\Transport\TransportInterface;
 use Jackalope\RepositoryFactoryFilesystem;
+use PHPCR\Shell\Config\Config;
 
 class JackalopeFs implements TransportInterface
 {
@@ -21,7 +22,7 @@ class JackalopeFs implements TransportInterface
         return 'jackalope-fs';
     }
 
-    public function getRepository(array $config)
+    public function getRepository(Config $config)
     {
         $params = array(
             'path'  => $config['repo_path'],

--- a/src/PHPCR/Shell/Transport/Transport/Jackrabbit.php
+++ b/src/PHPCR/Shell/Transport/Transport/Jackrabbit.php
@@ -13,6 +13,7 @@ namespace PHPCR\Shell\Transport\Transport;
 
 use Jackalope\RepositoryFactoryJackrabbit;
 use PHPCR\Shell\Transport\TransportInterface;
+use PHPCR\Shell\Config\Config;
 
 class Jackrabbit implements TransportInterface
 {
@@ -21,7 +22,7 @@ class Jackrabbit implements TransportInterface
         return 'jackrabbit';
     }
 
-    public function getRepository(array $config)
+    public function getRepository(Config $config)
     {
         $params = array(
             'jackalope.jackrabbit_uri'  => $config['repo_url'],

--- a/src/PHPCR/Shell/Transport/TransportInterface.php
+++ b/src/PHPCR/Shell/Transport/TransportInterface.php
@@ -11,6 +11,8 @@
 
 namespace PHPCR\Shell\Transport;
 
+use PHPCR\Shell\Config\Config;
+
 /**
  * All phpcr-shell transports must implement this interface
  *
@@ -20,5 +22,5 @@ interface TransportInterface
 {
     public function getName();
 
-    public function getRepository(array $config);
+    public function getRepository(Config $config);
 }


### PR DESCRIPTION
This PR fixes the configuration loading order. Configuration is now loaded from the profile after loading from the Input options.

Also passes the `Config` object rather than raw arrays to transports.