### PR TITLE
Introduce expression language in UPDATE queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ dev-master
 ### Features
 
 - [profile:show] Added command to display current profile
+- [query:update] Introduced `expr()` function to allow setting poperty values using expression language.
 
 ### Bug fixes
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "phpcr/phpcr-shell",
     "description": "Shell for PHPCR",
     "require": {
-        "symfony/console": "~2.3",
+        "symfony/console": "~2.4",
         "jackalope/jackalope": "~1.1",
         "phpcr/phpcr": "~2.1",
         "phpcr/phpcr-utils": "~1.2",
@@ -10,13 +10,14 @@
         "symfony/serializer": "~2.3",
         "symfony/yaml": "~2.3",
         "symfony/dependency-injection": "~2.3",
+        "symfony/expression-language": "~2.4",
         "dantleech/glob-finder": "~1.0"
     },
     "minimum-stability": "dev",
     "require-dev": {
         "symfony/symfony": "2.6",
-        "symfony/process": "~2.3",
-        "symfony/filesystem": "~2.3",
+        "symfony/process": "~2.4",
+        "symfony/filesystem": "~2.4",
         "phpunit/phpunit": "~3.7.28",
         "behat/behat": "~3.0.0",
         "phpspec/phpspec": "2.0",

--- a/features/all/phpcr_query_update.feature
+++ b/features/all/phpcr_query_update.feature
@@ -153,3 +153,30 @@ Feature: Execute a a raw UPDATE query in JCR_SQL2
             | UPDATE [nt:unstructured] mixin_foo('bar') |
             | UPDATE [nt:unstructured] APPLY mixin_foo('bar') |
             | UPDATE [nt:unstructured] mixin_foo'bar') |
+
+    Scenario Outline: Execute update query with expressions
+        When I execute the "<query>" command
+        Then the command should not fail
+        And I save the session
+        Then the node at "<path>" should have the property "<property>" with value "<expectedValue>"
+        And I should see the following:
+        """
+        1 row(s) affected
+        """
+        Examples:
+            | query | path | property | expectedValue |
+            | UPDATE [nt:unstructured] AS a SET a.title = expr('row.getNode().getName()') WHERE localname() = 'article1' | /cms/articles/article1 | title | article1 |
+            | UPDATE [nt:unstructured] AS a SET a.title = expr('row.getPath()') WHERE localname() = 'article1' | /cms/articles/article1 | title |  /cms/articles/article1 |
+
+    Scenario: Execute an update with a quoted expression (can't do this in Examples above)
+        When I execute the following command:
+        """
+        UPDATE [nt:unstructured] AS a SET a.weight = expr('row.getNode().getPropertyValue("weight") * 2') WHERE a.name = 'Product One'
+        """
+        Then the command should not fail
+        And I save the session
+        Then the node at "/cms/products/product1" should have the property "weight" with value "20"
+        And I should see the following:
+        """
+        1 row(s) affected
+        """

--- a/src/PHPCR/Shell/Console/Command/Phpcr/QueryUpdateCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/QueryUpdateCommand.php
@@ -90,7 +90,7 @@ EOT
         $result = $query->execute();
         $rows = 0;
 
-        $updateProcessor = new UpdateProcessor();
+        $updateProcessor = $this->get('query.update.processor');
 
         foreach ($result as $row) {
             $rows++;

--- a/src/PHPCR/Shell/DependencyInjection/Container.php
+++ b/src/PHPCR/Shell/DependencyInjection/Container.php
@@ -40,6 +40,7 @@ class Container extends ContainerBuilder
         $this->registerPhpcr();
         $this->registerEvent();
         $this->registerConsole();
+        $this->registerQuery();
     }
 
     public function registerHelpers()
@@ -165,6 +166,13 @@ class Container extends ContainerBuilder
         $this->register('console.input.autocomplete', 'PHPCR\Shell\Console\Input\AutoComplete')
             ->addArgument(new Reference('application'))
             ->addArgument(new Reference('phpcr.session'));
+    }
+
+    public function registerQuery()
+    {
+        $this->register('query.update.expression_language', 'Symfony\Component\ExpressionLanguage\ExpressionLanguage');
+        $this->register('query.update.processor', 'PHPCR\Shell\Query\UpdateProcessor')
+            ->addArgument(new Reference('query.update.expression_language'));
     }
 
     public function getMode()

--- a/src/PHPCR/Shell/Query/UpdateProcessor.php
+++ b/src/PHPCR/Shell/Query/UpdateProcessor.php
@@ -12,6 +12,7 @@
 namespace PHPCR\Shell\Query;
 
 use PHPCR\Query\RowInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 /**
  * Processor for node updates
@@ -25,7 +26,7 @@ class UpdateProcessor
      */
     private $functionMap = array();
 
-    public function __construct()
+    public function __construct(ExpressionLanguage $expressionLanguage)
     {
         $this->functionMapApply = array(
             'mixin_add' => function ($operand, $row, $mixinName) {
@@ -42,6 +43,14 @@ class UpdateProcessor
         );
 
         $this->functionMapSet = array(
+            'expr' => function ($operand, $row, $expression) use ($expressionLanguage) {
+                return $expressionLanguage->evaluate(
+                    $expression,
+                    array(
+                        'row' => $row,
+                    )
+                );
+            },
             'array_replace' => function ($operand, $row, $v, $x, $y) {
                 $operand->validateScalarArray($v);
                 foreach ($v as $key => $value) {

--- a/src/PHPCR/Shell/Test/ContextBase.php
+++ b/src/PHPCR/Shell/Test/ContextBase.php
@@ -152,6 +152,14 @@ abstract class ContextBase implements Context, SnippetAcceptingContext
     }
 
     /**
+     * @Given I execute the following command:
+     */
+    public function iExecuteTheFollowingCommand(PyStringNode $command)
+    {
+        $this->executeCommand($command);
+    }
+
+    /**
      * @Given /^I execute the following commands:$/
      */
     public function iExecuteTheFollowingCommands(TableNode $table)


### PR DESCRIPTION
This PR introduces the possiblitiy of setting property values to the result of an expression evaluation using the `$row` object.

For example:

````sql
UPDATE [nt:unstructured] AS a SET a.title = expr('row.getNode().getName()') WHERE localname() = 'article1'
UPDATE [nt:unstructured] AS a SET a.weight = expr('row.getNode().getPropertyValue("weight") * 2') WHERE a.name = 'Product One'
````