### PR TITLE
Do not access node when iterating over query result

### DIFF
--- a/src/PHPCR/Shell/Console/Helper/ResultFormatterHelper.php
+++ b/src/PHPCR/Shell/Console/Helper/ResultFormatterHelper.php
@@ -75,7 +75,6 @@ class ResultFormatterHelper extends Helper
         foreach ($result->getRows() as $row) {
             $values = array_merge(array(
                 $row->getPath(),
-                $row->getNode()->getIndex(),
             ), $row->getValues());
 
             foreach ($values as &$value) {


### PR DESCRIPTION
Currently we show the "index" of the node in the query result, which involves calling `getNode` on the `Row` object, which in turn causes a fetch from the database, slowing down everything.

Index is only used in association with same-name siblings, so not displaying it is not a big issue.