### PR TITLE
Trying to fix dev dependencires

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,6 @@
     "minimum-stability": "dev",
     "require-dev": {
         "symfony/symfony": "2.6",
-        "symfony/process": "~2.4",
-        "symfony/filesystem": "~2.4",
         "phpunit/phpunit": "~3.7.28",
         "behat/behat": "~3.0.0",
         "phpspec/phpspec": "2.0",


### PR DESCRIPTION
Since we explitly require `symfony/symfony` 2.6 in `composer.json`, the other `symfony` dependencies were redundant. Perhaps this will fix the build issue.