### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Shell for PHPCR
 
 The recommended way to use the PHPCR shell is as a phar archive.
 
-Install box: http://box-project.org
+Install box: https://box-project.github.io/box2/
 
 Build the PHAR:
 


### PR DESCRIPTION
Fix link to box-project (from lost domain `box-project.org` to current `https://box-project.github.io/box2/`).