### PR TITLE
Better aliasing

### DIFF
--- a/spec/PHPCR/Shell/Subscriber/AliasSubscriberSpec.php
+++ b/spec/PHPCR/Shell/Subscriber/AliasSubscriberSpec.php
@@ -32,8 +32,8 @@ class AliasSubscriberSpec extends ObjectBehavior
         );
 
         $config->getConfig('alias')->willReturn(array(
-            'ls' => 'list:command {arg1}',
-            'mv' => 'move {arg1} {arg2}',
+            'ls' => 'list:command',
+            'mv' => 'move',
         ));
     }
 
@@ -42,26 +42,10 @@ class AliasSubscriberSpec extends ObjectBehavior
         StringInput $input
     ) {
         $event->getInput()->willReturn($input);
+        $input->getRawCommand()->willReturn('ls -L5 --children');
         $input->getFirstArgument()->willReturn('ls');
-        $input->getTokens()->willReturn(array(
-            'ls', 'me'
-        ));
         $event->setInput(Argument::type('PHPCR\Shell\Console\Input\StringInput'))->shouldBeCalled();
 
-        $this->handleAlias($event)->shouldReturn('list:command me');
-    }
-
-    public function it_should_ommit_missing_arguments(
-        CommandPreRunEvent $event,
-        StringInput $input
-    ) {
-        $event->getInput()->willReturn($input);
-        $input->getFirstArgument()->willReturn('ls');
-        $input->getTokens()->willReturn(array(
-            'ls'
-        ));
-        $event->setInput(Argument::type('PHPCR\Shell\Console\Input\StringInput'))->shouldBeCalled();
-
-        $this->handleAlias($event)->shouldReturn('list:command');
+        $this->handleAlias($event)->shouldReturn('list:command -L5 --children');
     }
 }

--- a/src/PHPCR/Shell/Resources/config.dist/alias.yml
+++ b/src/PHPCR/Shell/Resources/config.dist/alias.yml
@@ -5,54 +5,54 @@ cinit: shell:config:init
 clear: shell:clear
 
 # MySQL commands
-use: workspace:use {arg1}
-explain: node-type:show {arg1}
+use: workspace:use
+explain: node-type:show
 
 # Filesystem commands
-cd: shell:path:change {arg1}
-rm: node:remove {arg1}
-mv: node:move {arg1} {arg2}
+cd: shell:path:change
+rm: node:remove
+mv: node:move
 pwd: shell:path:show
 exit: shell:exit
 
 # Node commands
-ls: node:list {arg1}
-ln: node:clone {arg1} {arg2} # symlink, as in ln -s
-cp: node:copy {arg1} {arg2}
-cat: node:property:show {arg1}
-touch: node:property:set {arg1} {arg2} {arg3}
-mkdir: node:create {arg1} {arg2}
+ls: node:list
+ln: node:clone # symlink, as in ln -s
+cp: node:copy
+cat: node:property:show
+touch: node:property:set
+mkdir: node:create
 
 # Node type commands
 mixins: node-type:list "^mix:"
-nodetypes: node-type:list {arg1}
-ntedit: node-type:edit {arg1}
-ntshow: node-type:show {arg1}
+nodetypes: node-type:list
+ntedit: node-type:edit
+ntshow: node-type:show
 
 # Workspace commands
 workspaces: workspace:list
 
 # Namespsce commands
-namespaces: workspace:namespace:list {arg1}
+namespaces: workspace:namespace:list
 nsset: workspace:namespace:register
 
 # Editor commands
-vi: node:edit {arg1} {arg2}
-vim: node:edit {arg1} {arg2}
-nano: node:edit {arg1} {arg2}
+vi: node:edit
+vim: node:edit
+nano: node:edit
 
 # GNU commands
-man: help {arg1}
+man: help
 
 # Version commands
-checkin: version:checkin {arg1}
-ci: version:checkin {arg1}
-co: version:checkout {arg1}
-checkout: version:checkout {arg1}
-cp: version:checkpoint {arg1}
-checkpoint: version:checkpoint {arg1}
-vhist: version:history {arg1}
-versions: version:history {arg1}
+checkin: version:checkin
+ci: version:checkin
+co: version:checkout
+checkout: version:checkout
+cp: version:checkpoint
+checkpoint: version:checkpoint
+vhist: version:history
+versions: version:history
 
 # Session commands
 save: session:save

--- a/src/PHPCR/Shell/Subscriber/AliasSubscriber.php
+++ b/src/PHPCR/Shell/Subscriber/AliasSubscriber.php
@@ -60,32 +60,8 @@ class AliasSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $commandTemplate = $aliasConfig[$commandName];
-        $replaces = array();
-
-        preg_match_all('{\{arg[0-9]+\}}', $commandTemplate, $matches);
-
-        $args = array();
-        if (isset($matches[0])) {
-            $args = $matches[0];
-        }
-
-        $tokens = $input->getTokens();
-
-        foreach ($tokens as $i => $token) {
-            if (strstr($token, ' ')) {
-                $token = escapeshellarg($token);
-            }
-            $replaces['{arg' . $i . '}'] = $token;
-        }
-
-        $command = strtr($commandTemplate, $replaces);
-
-        foreach ($args as $arg) {
-            $command = str_replace($arg, '', $command);
-        }
-
-        $command = trim($command);
+        $command = $aliasConfig[$commandName];
+        $command = $command .= substr($input->getRawCommand(), strlen($commandName));
 
         $newInput = new StringInput($command);
         $event->setInput($newInput);


### PR DESCRIPTION
Fixes https://github.com/phpcr/phpcr-shell/issues/168

Removes some random and unused functionality for the sake of being able to pass any arguments to aliases.

```
node:list -L2 --children # works
ls -L2 --children             # currently does not work, only applies -L2
```

This PR just removes the wierd substitution and passes the remaining arguments to the expanded command unmodified.