### PR TITLE
Command node:list (ls): Fix wrong node counter

### DIFF
--- a/features/all/phpcr_node_list.feature
+++ b/features/all/phpcr_node_list.feature
@@ -1,4 +1,4 @@
-Feature: List properites and chidren of current nodeA
+Feature: List properties and children of current nodeA
     In order to list the properties and children of the current node
     As a user that is logged into the shell
     I should be able to run a command which does that
@@ -136,7 +136,23 @@ Feature: List properites and chidren of current nodeA
         +---------------------+---------+--------------+
         """
 
-    Scenario: Correct node count
+    Scenario: Correct node count (simple)
+        Given I execute the "node:list /tests_general_base" command
+        Then the command should not fail
+        And I should see the following:
+        """
+        9 nodes, 1 properties in set
+        """
+
+    Scenario: Correct node count (recursive without properties)
+        Given I execute the "node:list --children --level=1 /tests_general_base" command
+        Then the command should not fail
+        And I should see the following:
+        """
+        16 nodes, 0 properties in set
+        """
+
+    Scenario: Correct node count (wildcard)
         Given I execute the "node:list /tests_general_base/*/jcr:content" command
         Then the command should not fail
         And I should see the following:

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeListCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeListCommand.php
@@ -124,7 +124,6 @@ HERE
             $this->renderNode($node, $table, [], $filter);
 
             if ($table->getNumberOfRows() > 0) {
-                $this->nbNodes++;
                 $output->writeln(sprintf('<pathbold>%s</pathbold> [%s] > %s',
                     $node->getPath(),
                     $node->getPrimaryNodeType()->getName(),
@@ -170,6 +169,7 @@ HERE
 
         $i = 0;
         foreach ($children as $child) {
+            $this->nbNodes++;
             $i++;
             if (isset($childNodeNames[$child->getName()])) {
                 unset($childNodeNames[$child->getName()]);
@@ -204,7 +204,6 @@ HERE
                     $newSpacers[] = '| ';
                 }
 
-                $this->nbNodes++;
                 $this->renderNode($child, $table, $newSpacers);
             }
         }


### PR DESCRIPTION
The displayed node counter for the 'ls' command is always set to 1.