### PR TITLE
Command shell:path:change (cd): Allow trailing slash on path

### DIFF
--- a/src/PHPCR/Shell/Phpcr/PhpcrSession.php
+++ b/src/PHPCR/Shell/Phpcr/PhpcrSession.php
@@ -104,6 +104,10 @@ class PhpcrSession implements SessionInterface
                 }
             }
 
+            if ($newPath !== '/') {
+                $newPath = rtrim($newPath, '/');
+            }
+
             // check that path is valid
             $this->getNode($newPath);
         }


### PR DESCRIPTION
The 'cd' command complains if the path ends with a slash. That's annoying.