### PR TITLE
Add php 7.x to the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ env:
 
 php:
     - 5.6
+    - 7.0
+    - 7.1
+    - 7.2
 
 before_script:
     - composer self-update

--- a/src/PHPCR/Shell/Test/CliContext.php
+++ b/src/PHPCR/Shell/Test/CliContext.php
@@ -39,7 +39,7 @@ class CliContext implements Context, SnippetAcceptingContext
 
         $this->rootPath = realpath(__DIR__.'/../../../..');
         $dir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'phpcr-shell'.DIRECTORY_SEPARATOR.
-            md5(microtime() * rand(0, 10000));
+            md5(microtime(true) * rand(0, 10000));
         $this->fixturesDir = realpath(__DIR__.'/../../../../features/fixtures/');
 
         $this->workingDir = $dir;

--- a/src/PHPCR/Shell/Test/ContextBase.php
+++ b/src/PHPCR/Shell/Test/ContextBase.php
@@ -50,7 +50,7 @@ abstract class ContextBase implements Context, SnippetAcceptingContext
     public function beforeScenario()
     {
         $dir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'phpcr-shell'.DIRECTORY_SEPARATOR.
-            md5(microtime() * rand(0, 10000));
+            md5(microtime(true) * rand(0, 10000));
 
         $this->workingDir = $dir;
 


### PR DESCRIPTION
Fix behat runtime errors by using php 7.x
Travis: build with 7.x