### PR TITLE
specify the supported php versions to avoid installing with unsupported versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "phpcr/phpcr-shell",
     "description": "Shell for PHPCR",
     "require": {
+        "php": "^5.6|^7.0",
         "symfony/console": "~2.8|~3.0",
         "jackalope/jackalope": "~1.1",
         "phpcr/phpcr": "~2.1",


### PR DESCRIPTION
we never specified the php versions we support, but we should do that. #194 is adding the tests for php 7.