### PR TITLE
Query result formatter: remove column 'Index' from table head

### DIFF
--- a/src/PHPCR/Shell/Console/Helper/ResultFormatterHelper.php
+++ b/src/PHPCR/Shell/Console/Helper/ResultFormatterHelper.php
@@ -68,7 +68,6 @@ class ResultFormatterHelper extends Helper
         $table = new Table($output);
         $table->setHeaders(array_merge([
             'Path',
-            'Index',
         ], $result->getColumnNames()));
 
         foreach ($result->getRows() as $row) {


### PR DESCRIPTION
There is no data column for the head column 'Index'.