### PR TITLE
Update branch alias for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "bin": ["bin/phpcrsh"],
     "extra": {
         "branch-alias": {
-            "dev-master": "1.2-dev"
+            "dev-master": "1.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "bin": ["bin/phpcrsh"],
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "1.2-dev"
         }
     }
 }


### PR DESCRIPTION
Currently the following command  does not install the latest master branch version instead you get 1.1.1:

```bash
composer require phpcr/phpcr-shell:^1.0@dev`

#   - Installing phpcr/phpcr-shell (1.1.1): Downloading (100%)
```

Not sure as we removed symfony <= 4 compatibility if it will be `1.2-dev` or `2-0-dev`:

