### PR TITLE
Fix namespace error in composer 2

### DIFF
--- a/src/PHPCR/Shell/Query/Validator.php
+++ b/src/PHPCR/Shell/Query/Validator.php
@@ -10,7 +10,7 @@
  *
  */
 
-namespace \PHPCR\Shell\Query;
+namespace PHPCR\Shell\Query;
 
 class Validator
 {


### PR DESCRIPTION
`composer dump-autoload --optimize` will warn with:

```
Class Validator located in ./vendor/phpcr/phpcr-shell/src/PHPCR/Shell/Query/Validator.php does not comply with psr-0 autoloading standard. Skipping.
```