### PR TITLE
Test CI against jackalope 2.0@dev version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "require": {
         "php": "^8.0",
         "symfony/console": "^5.0 || ^6.0",
-        "jackalope/jackalope": "dev-static-typing as 2.0",
+        "jackalope/jackalope": "^2.0@dev",
         "phpcr/phpcr": "^2.1",
         "phpcr/phpcr-utils": "^1.2",
         "symfony/finder": "^5.0 || ^6.0",
@@ -18,8 +18,8 @@
         "phpunit/phpunit": "^9.5",
         "behat/behat": "^3.10",
         "phpspec/phpspec": "^7.2",
-        "jackalope/jackalope-doctrine-dbal": "dev-upgrade-to-2 as 2.0",
-        "jackalope/jackalope-jackrabbit": "dev-upgrade-to-2 as 2.0",
+        "jackalope/jackalope-doctrine-dbal": "^2.0@dev",
+        "jackalope/jackalope-jackrabbit": "^2.0@dev",
         "phpspec/prophecy-phpunit": "^2.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "require": {
         "php": "^8.0",
         "symfony/console": "^5.0 || ^6.0",
-        "jackalope/jackalope": "dev-static-typing@dev as 2.0",
+        "jackalope/jackalope": "dev-static-typing as 2.0",
         "phpcr/phpcr": "^2.1",
         "phpcr/phpcr-utils": "^1.2",
         "symfony/finder": "^5.0 || ^6.0",
@@ -18,8 +18,8 @@
         "phpunit/phpunit": "^9.5",
         "behat/behat": "^3.10",
         "phpspec/phpspec": "^7.2",
-        "jackalope/jackalope-doctrine-dbal": "dev-upgrade-to-2@dev as 2.0",
-        "jackalope/jackalope-jackrabbit": "dev-upgrade-to-2@dev as 2.0",
+        "jackalope/jackalope-doctrine-dbal": "dev-upgrade-to-2 as 2.0",
+        "jackalope/jackalope-jackrabbit": "dev-upgrade-to-2 as 2.0",
         "phpspec/prophecy-phpunit": "^2.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "require": {
         "php": "^8.0",
         "symfony/console": "^5.0 || ^6.0",
-        "jackalope/jackalope": "^1.3.4",
+        "jackalope/jackalope": "dev-static-typing@dev as 2.0",
         "phpcr/phpcr": "^2.1",
         "phpcr/phpcr-utils": "^1.2",
         "symfony/finder": "^5.0 || ^6.0",
@@ -18,8 +18,8 @@
         "phpunit/phpunit": "^9.5",
         "behat/behat": "^3.10",
         "phpspec/phpspec": "^7.2",
-        "jackalope/jackalope-doctrine-dbal": "^1.3",
-        "jackalope/jackalope-jackrabbit": "^1.4.4",
+        "jackalope/jackalope-doctrine-dbal": "dev-upgrade-to-2@dev as 2.0",
+        "jackalope/jackalope-jackrabbit": "dev-upgrade-to-2@dev as 2.0",
         "phpspec/prophecy-phpunit": "^2.0"
     },
     "suggest": {


### PR DESCRIPTION
A new version is in work by @dbu which uses static typings and get ride of doctrine/cache. This pull request tests CI against jackalope 2.0@dev version.