### PR TITLE
Defaulting to xdg directory for history files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.5.0
+-----
+
+- Moving the history file from the home directory to the `XDG_DATA_HOME` directory #217
+
 1.4.0
 -----
 
@@ -44,7 +49,7 @@ beta4
 - [node:property:show] Text fields are truncated
 - [profile] Workspace given from CLI does not override profile workspace
 - [command] Removed node:definition command: Jackalope now supports this, and
-  this command would never have worked, see: 
+  this command would never have worked, see:
 
 beta2
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 1.5.0
 -----
 
-- Moving the history file from the home directory to the `XDG_DATA_HOME` directory #217
+- If `XDG_DATA_HOME` is defined, it is now used as location where to store the history.
+  If you have set `XDG_DATA_HOME` to something else than `HOME`, you can preserve your phpcr-shell history by moving the directory `~/.history_PHPCRSH` to `$XDB_DATA_HOME/.history_PHPCRSH`.
 
 1.4.0
 -----

--- a/src/PHPCR/Shell/Console/Application/Shell.php
+++ b/src/PHPCR/Shell/Console/Application/Shell.php
@@ -41,9 +41,19 @@ class Shell
     {
         $this->hasReadline = function_exists('readline');
         $this->application = $application;
-        $this->history = getenv('HOME').'/.history_'.$application->getName();
+        $this->history = $this->getHistoryDirectory();
         $this->output = new ConsoleOutput();
         $this->prompt = $application->getName().' > ';
+    }
+
+    public function getHistoryDirectory(): string
+    {
+        $dataDirectory = getenv('XDG_DATA_HOME');
+        if ($dataDirectory !== '') {
+            return $dataDirectory.'/'.$this->application->getName();
+        }
+
+        return getenv('HOME').'/.history_'.$this->application->getName();
     }
 
     /**


### PR DESCRIPTION
Implement the [xdg standard](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) since I was cleaning my home directory.

This makes the history file less accessible, but I think that for a history file this is okay.