### PR TITLE
Adding `void` return type to command

### DIFF
--- a/src/PHPCR/Shell/Console/Command/Phpcr/AccessControlPrivilegeListCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/AccessControlPrivilegeListCommand.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class AccessControlPrivilegeListCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('access-control:privilege:list');
         $this->setDescription('List the privileges of the repository or a specific node');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/LockInfoCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/LockInfoCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class LockInfoCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('lock:info');
         $this->setDescription('Show details of the lock that applies to the specified node path');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/LockLockCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/LockLockCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class LockLockCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('lock:lock');
         $this->setDescription('Lock the node at the given path');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/LockRefreshCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/LockRefreshCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class LockRefreshCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('lock:refresh');
         $this->setDescription('Refresh the TTL of the lock of the node at the given path');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/LockTokenAddCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/LockTokenAddCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class LockTokenAddCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('lock:token:add');
         $this->setDescription('Add a lock token to the current session');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/LockTokenListCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/LockTokenListCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class LockTokenListCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('lock:token:list');
         $this->setDescription('List a lock token to the current session');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/LockTokenRemoveCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/LockTokenRemoveCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class LockTokenRemoveCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('lock:token:remove');
         $this->setDescription('Remove a lock token to the current session');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/LockUnlockCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/LockUnlockCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class LockUnlockCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('lock:unlock');
         $this->setDescription('Unlock the node at the given path');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeCloneCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeCloneCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class NodeCloneCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node:clone');
         $this->setDescription('Clone a node (immediate)');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeCopyCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeCopyCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class NodeCopyCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node:copy');
         $this->setDescription('Copy a node (immediate)');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeCorrespondingCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeCorrespondingCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class NodeCorrespondingCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node:corresponding');
         $this->setDescription('Show the path for the current nodes corresponding path in named workspace');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeCreateCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeCreateCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class NodeCreateCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node:create');
         $this->setDescription('Create a node at the current path');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeEditCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeEditCommand.php
@@ -25,7 +25,7 @@ use Symfony\Component\Serializer\Serializer;
 
 class NodeEditCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node:edit');
         $this->setDescription('Edit the given node in the EDITOR configured by the system');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeFileImportCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeFileImportCommand.php
@@ -26,7 +26,7 @@ class NodeFileImportCommand extends BasePhpcrCommand
      */
     protected $session;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('file:import');
         $this->setDescription('Import a file at the given path');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeInfoCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeInfoCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class NodeInfoCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node:info');
         $this->setDescription('Show information about the current node');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeLifecycleFollowCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeLifecycleFollowCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class NodeLifecycleFollowCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node:lifecycle:follow');
         $this->setDescription('Causes the lifecycle state of this node to undergo the specified transition.');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeLifecycleListCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeLifecycleListCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class NodeLifecycleListCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node:lifecycle:list');
         $this->setDescription('Returns the list of valid state transitions for this node.');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeListCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeListCommand.php
@@ -33,7 +33,7 @@ class NodeListCommand extends BasePhpcrCommand
     protected $nbNodes = 0;
     protected $nbProperties = 0;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node:list');
         $this->setDescription('List the children / properties of this node at the given path or with the given UUID');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeMixinAddCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeMixinAddCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class NodeMixinAddCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node:mixin:add');
         $this->setDescription('Add the named mixin to the node (can include wildcards)');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeMixinRemoveCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeMixinRemoveCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class NodeMixinRemoveCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node:mixin:remove');
         $this->setDescription('Remove the named mixin to the current node');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeMoveCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeMoveCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class NodeMoveCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node:move');
         $this->setDescription('Move a node in the current session');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeOrderBeforeCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeOrderBeforeCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class NodeOrderBeforeCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node:order-before');
         $this->setDescription('Reorder a child node of the current node');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodePropertyRemoveCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodePropertyRemoveCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class NodePropertyRemoveCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node:property:remove');
         $this->setDescription('Remove the property at the given absolute path');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodePropertySetCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodePropertySetCommand.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class NodePropertySetCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node:property:set');
         $this->setDescription('Rename the node at the current path');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodePropertyShowCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodePropertyShowCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class NodePropertyShowCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node:property:show');
         $this->setDescription('Show the property at the given path');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeReferencesCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeReferencesCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class NodeReferencesCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node:references');
         $this->setDescription('Returns all REFERENCE properties that refer to this node');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeRemoveCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeRemoveCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class NodeRemoveCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node:remove');
         $this->setDescription('Remove the node at path (can include wildcards)');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeRenameCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeRenameCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class NodeRenameCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node:rename');
         $this->setDescription('Rename the node at the current path');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeSetPrimaryTypeCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeSetPrimaryTypeCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class NodeSetPrimaryTypeCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node:set-primary-type');
         $this->setDescription('Set the primary type of the current node');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeSharedShowCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeSharedShowCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class NodeSharedShowCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node:shared:show');
         $this->setDescription('Show all the nodes are in the shared set of this node');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeTypeEditCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeTypeEditCommand.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class NodeTypeEditCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node-type:edit');
         $this->setDescription('Edit or create a node type');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeTypeListCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeTypeListCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class NodeTypeListCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node-type:list');
         $this->setDescription('List registered node types');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeTypeLoadCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeTypeLoadCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class NodeTypeLoadCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node-type:load');
         $this->setDescription('Load or create a node type');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeTypeShowCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeTypeShowCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class NodeTypeShowCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node-type:show');
         $this->setDescription('Show the CND of a node type');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeTypeUnregisterCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeTypeUnregisterCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class NodeTypeUnregisterCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node-type:unregister');
         $this->setDescription('Unregister a node type UNSUPPORTED / TODO');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/NodeUpdateCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/NodeUpdateCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class NodeUpdateCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('node:update');
         $this->setDescription('Updates a node corresponding to the given path in the given workspace');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/QueryCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/QueryCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class QueryCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('query');
         $this->setDescription('Execute a SELECT query (advanced)');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/QueryDeleteCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/QueryDeleteCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class QueryDeleteCommand extends BaseQueryCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('delete');
         $this->setDescription('Execute a DELETE query (non standard)');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/QuerySelectCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/QuerySelectCommand.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class QuerySelectCommand extends BaseQueryCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('select');
         $this->setDescription('Execute a SELECT query (JCR-SQL2)');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/QueryUpdateCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/QueryUpdateCommand.php
@@ -23,7 +23,7 @@ class QueryUpdateCommand extends BaseQueryCommand
      */
     protected $output;
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('update');
         $this->setDescription('Execute an UPDATE query (non-standard)');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/RepositoryDescriptorListCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/RepositoryDescriptorListCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class RepositoryDescriptorListCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('repository:descriptor:list');
         $this->setDescription('List the descriptors for the current repository');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/RetentionHoldAddCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/RetentionHoldAddCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class RetentionHoldAddCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('retention:hold:add');
         $this->setDescription('Adds a retention hold UNSUPPORTED');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/RetentionHoldListCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/RetentionHoldListCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class RetentionHoldListCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('retention:hold:list');
         $this->setDescription('List retention holds at given absolute path UNSUPPORTED');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/RetentionHoldRemoveCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/RetentionHoldRemoveCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class RetentionHoldRemoveCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('retention:hold:remove');
         $this->setDescription('Removes a retention hold UNSUPPORTED');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/RetentionPolicyGetCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/RetentionPolicyGetCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class RetentionPolicyGetCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('retention:policy:get');
         $this->setDescription('Get a retention policy for specified node UNSUPPORTED');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/RetentionPolicyRemoveCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/RetentionPolicyRemoveCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class RetentionPolicyRemoveCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('retention:policy:remove');
         $this->setDescription('Remove a retention policy for specified node UNSUPPORTED');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/SessionExportCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/SessionExportCommand.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class SessionExportCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('session:export');
         $this->setDescription('Export the session to XML');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/SessionImpersonateCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/SessionImpersonateCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SessionImpersonateCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('session:impersonate');
         $this->setDescription('Impersonate the given user');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/SessionImportCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/SessionImportCommand.php
@@ -27,7 +27,7 @@ class SessionImportCommand extends BasePhpcrCommand
         'collision-throw',
     ];
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('session:import');
         $this->setDescription('Import content from an XML file');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/SessionInfoCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/SessionInfoCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SessionInfoCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('session:info');
         $this->setDescription('Display information about current session');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/SessionLoginCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/SessionLoginCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SessionLoginCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('session:login');
         $this->setDescription('Login or (relogin) to a session');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/SessionLogoutCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/SessionLogoutCommand.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SessionLogoutCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('session:logout');
         $this->setDescription('Logout of the current session');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/SessionNamespaceListCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/SessionNamespaceListCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SessionNamespaceListCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('session:namespace:list');
         $this->setDescription('List all namespace prefix to URI  mappings in current session');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/SessionNamespaceSetCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/SessionNamespaceSetCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SessionNamespaceSetCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('session:namespace:set');
         $this->setDescription('Set a namespace in the current session');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/SessionRefreshCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/SessionRefreshCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SessionRefreshCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('session:refresh');
         $this->setDescription('Refresh the current session');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/SessionSaveCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/SessionSaveCommand.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SessionSaveCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('session:save');
         $this->setDescription('Save the current session');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/VersionCheckinCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/VersionCheckinCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class VersionCheckinCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('version:checkin');
         $this->setDescription('Checkin (commit) a node version');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/VersionCheckoutCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/VersionCheckoutCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class VersionCheckoutCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('version:checkout');
         $this->setDescription('Checkout a node version and enable changes to be made');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/VersionCheckpointCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/VersionCheckpointCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class VersionCheckpointCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('version:checkpoint');
         $this->setDescription('Checkin and then checkout a node');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/VersionHistoryCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/VersionHistoryCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class VersionHistoryCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('version:history');
         $this->setDescription('Show version history of node at given absolute path');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/VersionRemoveCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/VersionRemoveCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class VersionRemoveCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('version:remove');
         $this->setDescription('Remove a node version');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/VersionRestoreCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/VersionRestoreCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class VersionRestoreCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('version:restore');
         $this->setDescription('Restore a node version');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/WorkspaceCreateCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/WorkspaceCreateCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class WorkspaceCreateCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('workspace:create');
         $this->setDescription('Create a new workspace');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/WorkspaceDeleteCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/WorkspaceDeleteCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class WorkspaceDeleteCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('workspace:delete');
         $this->setDescription('Delete a workspace');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/WorkspaceListCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/WorkspaceListCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class WorkspaceListCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('workspace:list');
         $this->setDescription('Lists workspaces in the current repository');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/WorkspaceNamespaceListCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/WorkspaceNamespaceListCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class WorkspaceNamespaceListCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('workspace:namespace:list');
         $this->setDescription('List all namespace prefix to URI  mappings in current workspace');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/WorkspaceNamespaceRegisterCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/WorkspaceNamespaceRegisterCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class WorkspaceNamespaceRegisterCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('workspace:namespace:register');
         $this->setDescription('Sets a one-to-one mapping between prefix and uri in the global namespace');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/WorkspaceNamespaceUnregisterCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/WorkspaceNamespaceUnregisterCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class WorkspaceNamespaceUnregisterCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('workspace:namespace:unregister');
         $this->setDescription('Unregister a namespace');

--- a/src/PHPCR/Shell/Console/Command/Phpcr/WorkspaceUseCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Phpcr/WorkspaceUseCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class WorkspaceUseCommand extends BasePhpcrCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('workspace:use');
         $this->setDescription('Change the current workspace');

--- a/src/PHPCR/Shell/Console/Command/Shell/AliasListCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Shell/AliasListCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class AliasListCommand extends BaseCommand
 {
-    public function configure()
+    public function configure(): void
     {
         $this->setName('shell:alias:list');
         $this->setDescription('List all the registered aliases');

--- a/src/PHPCR/Shell/Console/Command/Shell/ClearCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Shell/ClearCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ClearCommand extends BaseCommand
 {
-    public function configure()
+    public function configure(): void
     {
         $this->setName('shell:clear');
         $this->setDescription('Clear the screen');

--- a/src/PHPCR/Shell/Console/Command/Shell/ConfigInitCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Shell/ConfigInitCommand.php
@@ -20,7 +20,7 @@ class ConfigInitCommand extends BaseCommand
 {
     protected $output;
 
-    public function configure()
+    public function configure(): void
     {
         $this->setName('shell:config:init');
         $this->setDescription('Initialize a local configuration with default values');

--- a/src/PHPCR/Shell/Console/Command/Shell/ConfigReloadCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Shell/ConfigReloadCommand.php
@@ -20,7 +20,7 @@ class ConfigReloadCommand extends BaseCommand
 {
     protected $output;
 
-    public function configure()
+    public function configure(): void
     {
         $this->setName('shell:config:reload');
         $this->setDescription('Reload the configuration');

--- a/src/PHPCR/Shell/Console/Command/Shell/ExitCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Shell/ExitCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class ExitCommand extends BaseCommand
 {
-    public function configure()
+    public function configure(): void
     {
         $this->setName('shell:exit');
         $this->setDescription('Logout and quit the shell');

--- a/src/PHPCR/Shell/Console/Command/Shell/PathChangeCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Shell/PathChangeCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class PathChangeCommand extends BaseCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('shell:path:change');
         $this->setDescription('Change the current path');

--- a/src/PHPCR/Shell/Console/Command/Shell/PathShowCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Shell/PathShowCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class PathShowCommand extends BaseCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('shell:path:show');
         $this->setDescription('Print Working Directory (or path)');

--- a/src/PHPCR/Shell/Console/Command/Shell/ProfileShowCommand.php
+++ b/src/PHPCR/Shell/Console/Command/Shell/ProfileShowCommand.php
@@ -21,7 +21,7 @@ class ProfileShowCommand extends BaseCommand
 {
     protected $output;
 
-    public function configure()
+    public function configure(): void
     {
         $this->setName('shell:profile:show');
         $this->setDescription('Show the current profile configuration');

--- a/src/PHPCR/Shell/Console/Command/ShellCommand.php
+++ b/src/PHPCR/Shell/Console/Command/ShellCommand.php
@@ -49,7 +49,7 @@ class ShellCommand extends Command
     /**
      * {@inheritdoc}
      */
-    public function configure()
+    public function configure(): void
     {
         $this->setName('phpcr_shell');
         $this->setDefinition([


### PR DESCRIPTION
In Symfony 6 not having this type is deprecated and it can't hurt in 5.4 either. This is not a BC break as Return Type narrowing (the implementation of an interface can have a narrower return type than the interface implementing it) was introduced in 7.4 and the result of the configure method is used nowhere.