### PR TITLE
Add PHP 8.2 to test matrix

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -45,6 +45,18 @@ jobs:
                       dependencies: highest
                       behat-suite: cli
 
+                    - php-version: '8.2'
+                      dependencies: highest
+                      behat-suite: standalone
+
+                    - php-version: '8.2'
+                      dependencies: highest
+                      behat-suite: embedded
+
+                    - php-version: '8.2'
+                      dependencies: highest
+                      behat-suite: cli
+
         steps:
             - name: Checkout project
               uses: actions/checkout@v2


### PR DESCRIPTION
Add PHP 8.2 to test matrix to later Support Symfony 7.

PHP 8.3 can not be added aslong as prophecy is not compatible with it.