### PR TITLE
Update phpcr-shell to Symfony 7

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -48,14 +48,17 @@ jobs:
                     - php-version: '8.2'
                       dependencies: highest
                       behat-suite: standalone
+                      composer-stability: 'dev'
 
                     - php-version: '8.2'
                       dependencies: highest
                       behat-suite: embedded
+                      composer-stability: 'dev'
 
                     - php-version: '8.2'
                       dependencies: highest
                       behat-suite: cli
+                      composer-stability: 'dev'
 
         steps:
             - name: Checkout project
@@ -73,6 +76,10 @@ jobs:
               with:
                   php-version: ${{ matrix.php-version }}
                   tools: 'composer:v2'
+
+            - name: Set composer stability
+              if: ${{ matrix.composer-stability }}
+              run: composer config minimum-stability ${{ matrix.composer-stability }}
 
             - name: Install dependencies with Composer
               uses: ramsey/composer-install@v2

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -48,14 +48,26 @@ jobs:
                     - php-version: '8.2'
                       dependencies: highest
                       behat-suite: standalone
-                      composer-stability: 'dev'
 
                     - php-version: '8.2'
                       dependencies: highest
                       behat-suite: embedded
-                      composer-stability: 'dev'
 
                     - php-version: '8.2'
+                      dependencies: highest
+                      behat-suite: cli
+
+                    - php-version: '8.3'
+                      dependencies: highest
+                      behat-suite: standalone
+                      composer-stability: 'dev'
+
+                    - php-version: '8.3'
+                      dependencies: highest
+                      behat-suite: embedded
+                      composer-stability: 'dev'
+
+                    - php-version: '8.3'
                       dependencies: highest
                       behat-suite: cli
                       composer-stability: 'dev'

--- a/composer.json
+++ b/composer.json
@@ -3,15 +3,15 @@
     "description": "Shell for PHPCR",
     "require": {
         "php": "^8.0",
-        "symfony/console": "^5.0 || ^6.0",
+        "symfony/console": "^5.0 || ^6.0 || ^7.0",
         "jackalope/jackalope": "^1.3.4",
         "phpcr/phpcr": "^2.1",
-        "phpcr/phpcr-utils": "^1.2",
-        "symfony/finder": "^5.0 || ^6.0",
-        "symfony/serializer": "^5.0 || ^6.0",
-        "symfony/yaml": "^5.0 || ^6.0",
-        "symfony/dependency-injection": "^5.0 || ^6.0",
-        "symfony/expression-language": "^5.0 || ^6.0",
+        "phpcr/phpcr-utils": "^1.2 || ^2.0",
+        "symfony/finder": "^5.0 || ^6.0 || ^7.0",
+        "symfony/serializer": "^5.0 || ^6.0 || ^7.0",
+        "symfony/yaml": "^5.0 || ^6.0 || ^7.0",
+        "symfony/dependency-injection": "^5.0 || ^6.0 || ^7.0",
+        "symfony/expression-language": "^5.0 || ^6.0 || ^7.0",
         "dantleech/glob-finder": "^1.0"
     },
     "require-dev": {

--- a/src/PHPCR/Shell/Serializer/NodeNormalizer.php
+++ b/src/PHPCR/Shell/Serializer/NodeNormalizer.php
@@ -93,7 +93,7 @@ class NodeNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function denormalize($data, $class, $format = null, array $context = [])
+    public function denormalize($data, $class, $format = null, array $context = []): mixed
     {
         if (!$data) {
             throw new \InvalidArgumentException(

--- a/src/PHPCR/Shell/Serializer/NodeNormalizer.php
+++ b/src/PHPCR/Shell/Serializer/NodeNormalizer.php
@@ -39,14 +39,21 @@ class NodeNormalizer implements NormalizerInterface, DenormalizerInterface
         return $this->notes;
     }
 
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            NodeInterface::class => true,
+        ];
+    }
+
     /**
      * {@inheritdoc}
      */
-    public function normalize($node, $format = null, array $context = []): ArrayObject|array|string|int|float|bool|null
+    public function normalize($object, $format = null, array $context = []): array
     {
         $res = [];
 
-        foreach ($node->getProperties() as $property) {
+        foreach ($object->getProperties() as $property) {
             if (false === $this->isPropertyEditable($property)) {
                 continue;
             }
@@ -80,13 +87,6 @@ class NodeNormalizer implements NormalizerInterface, DenormalizerInterface
         }
 
         return $res;
-    }
-
-    public function getSupportedTypes(?string $format): array
-    {
-        return [
-            NodeInterface::class => true,
-        ];
     }
 
     /**

--- a/src/PHPCR/Shell/Serializer/NodeNormalizer.php
+++ b/src/PHPCR/Shell/Serializer/NodeNormalizer.php
@@ -166,7 +166,7 @@ class NodeNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization($data, $type, $format = null)
+    public function supportsDenormalization($data, $type, $format = null, array $context = []): bool
     {
         return $type === 'PHPCR\NodeInterface';
     }

--- a/src/PHPCR/Shell/Serializer/NodeNormalizer.php
+++ b/src/PHPCR/Shell/Serializer/NodeNormalizer.php
@@ -85,7 +85,7 @@ class NodeNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null): bool
+    public function supportsNormalization($data, $format = null, array $context = []): bool
     {
         return is_object($data) && $data instanceof NodeInterface;
     }

--- a/src/PHPCR/Shell/Serializer/NodeNormalizer.php
+++ b/src/PHPCR/Shell/Serializer/NodeNormalizer.php
@@ -85,7 +85,7 @@ class NodeNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return is_object($data) && $data instanceof NodeInterface;
     }

--- a/src/PHPCR/Shell/Serializer/NodeNormalizer.php
+++ b/src/PHPCR/Shell/Serializer/NodeNormalizer.php
@@ -82,6 +82,13 @@ class NodeNormalizer implements NormalizerInterface, DenormalizerInterface
         return $res;
     }
 
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            NodeInterface::class => true,
+        ];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/PHPCR/Shell/Serializer/NodeNormalizer.php
+++ b/src/PHPCR/Shell/Serializer/NodeNormalizer.php
@@ -42,7 +42,7 @@ class NodeNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($node, $format = null, array $context = [])
+    public function normalize($node, $format = null, array $context = []): ArrayObject|array|string|int|float|bool|null
     {
         $res = [];
 

--- a/src/PHPCR/Shell/Serializer/YamlEncoder.php
+++ b/src/PHPCR/Shell/Serializer/YamlEncoder.php
@@ -33,7 +33,7 @@ class YamlEncoder implements EncoderInterface, DecoderInterface
         return Yaml::dump($data);
     }
 
-    public function decode($data, $format, array $context = [])
+    public function decode($data, $format, array $context = []): mixed
     {
         $arr = Yaml::parse($data);
 


### PR DESCRIPTION
Build on top of: https://github.com/phpcr/phpcr-shell/pull/223

Still on Symfony 6 instead of 7:

```
symfony/config                     v6.4.0  Helps you find, load, combine, autofill and validate ...
symfony/console                    v6.4.0  Eases the creation of beautiful and testable command ...
symfony/dependency-injection       v6.4.0  Allows you to standardize and centralize the way obje...
symfony/event-dispatcher           v6.4.0  Provides tools that allow your application components...
symfony/finder                     v6.4.0  Finds files and directories via an intuitive fluent i...
symfony/process                    v6.4.0  Executes commands in sub-processes
symfony/translation                v6.4.0  Provides tools to internationalize your application
symfony/yaml                       v6.4.0  Loads and dumps YAML files
```

Following deps blocking this updates:

```
behat/behat       v3.13.0 requires symfony/console (^4.4 || ^5.0 || ^6.0)
phpcr/phpcr-utils 1.8.1   requires symfony/console (^2.3 || ^3.0 || ^4.0 || ^5.0 || ^6.0)
phpspec/phpspec   7.4.0   requires symfony/console (^3.4 || ^4.4 || ^5.0 || ^6.0)
```

# TODO

 - [x] https://github.com/phpcr/phpcr-utils/pull/214 (release missing)
 - [x] https://github.com/phpspec/phpspec/pull/1452
 - [x] https://github.com/Behat/Behat/pull/1442
 - [x]  PHP Fatal error:  Declaration of PHPCR\Shell\Serializer\NodeNormalizer::normalize($node, $format = null, array $context = []) must be compatible with Symfony\Component\Serializer\Normalizer\NormalizerInterface::normalize(mixed $object, ?string $format = null, array $context = []): ArrayObject|array|string|int|float|bool|null in /home/runner/work/phpcr-shell/phpcr-shell/src/PHPCR/Shell/Serializer/NodeNormalizer.php on line 45
 - [ ] Uncaught Error: Interface "Symfony\Component\DependencyInjection\ContainerAwareInterface" not found in /home/runner/work/phpcr-shell/phpcr-shell/src/PHPCR/Shell/Console/Command/BaseCommand.php:19