### PR TITLE
Fix autoload issue with roave/better-reflection SourceLocator Psr0Mapping

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "doctrine/phpcr-bundle": "<=1.2.1"
     },
     "autoload": {
-        "psr-0": {"": "src"}
+        "psr-4": {"PHPCR\\Shell\\": "src/PHPCR/Shell"}
     },
     "bin": ["bin/phpcrsh"]
 }


### PR DESCRIPTION
While give `roave/backward-compatibility-check` a try I stumbled over that it don't like the PSR Mapping of this package.

```
In InvalidPrefixMapping.php line 15:

  [Roave\BetterReflection\SourceLocator\Type\Composer\Psr\Exception\InvalidPrefixMapping]
  An invalid empty string provided as a PSR mapping prefix


Exception trace:
  at /Users/alexanderschranz/Documents/Projects/sulu-develop.localhost/vendor/sulu/sulu/vendor/roave/better-reflection/src/SourceLocator/Type/Composer/Psr/Exception/InvalidPrefixMapping.php:15
 Roave\BetterReflection\SourceLocator\Type\Composer\Psr\Exception\InvalidPrefixMapping::emptyPrefixGiven() at /Users/alexanderschranz/Documents/Projects/sulu-develop.localhost/vendor/sulu/sulu/vendor/roave/better-reflection/src/SourceLocator/Type/Composer/Psr/Psr0Mapping.php:83
 ```